### PR TITLE
[FU-80] photographer mypage layout

### DIFF
--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -1,9 +1,9 @@
 import BackgroundImage from "@/containers/customer/main/background-image";
 import InfoSheet from "@/containers/customer/main/info-sheet";
-import { Link } from "profile-types";
+import { LinkType } from "profile-types";
 
 const CustomerMainPage = ({ params }: { params: { id: string } }) => {
-  const defaultLinks: Link[] = [
+  const defaultLinks: LinkType[] = [
     { name: "상품 선택하기", src: "/products" },
     { name: "일정 확인하기 ", src: "/schedules" },
     { name: "자주 묻는 질문", src: "/faqs" },

--- a/src/app/photographer/layout.tsx
+++ b/src/app/photographer/layout.tsx
@@ -7,7 +7,10 @@ const PhotographerLayout = ({
   children: React.ReactNode;
 }>) => {
   return (
-    <div className={styles.center}>
+    <div
+      className={styles.center}
+      style={{ minWidth: "900px", width: "100vw", overflowX: "scroll" }}
+    >
       <Header />
       <div>{children}</div>
     </div>

--- a/src/app/photographer/mypage/faqs/page.tsx
+++ b/src/app/photographer/mypage/faqs/page.tsx
@@ -1,0 +1,11 @@
+import Preparing from "@/containers/mypage/preparing";
+
+const MyFaqsPage = () => {
+  return (
+    <div>
+      <Preparing />
+    </div>
+  );
+};
+
+export default MyFaqsPage;

--- a/src/app/photographer/mypage/layout.tsx
+++ b/src/app/photographer/mypage/layout.tsx
@@ -9,7 +9,7 @@ const MypageLayout = ({
   return (
     <div
       className={styles.center}
-      style={{ display: "flex", flexDirection: "row" }}
+      style={{ display: "flex", flexDirection: "row", width: "100vw" }}
     >
       <Navbar />
       <div style={{ flex: 1 }}>{children}</div>

--- a/src/app/photographer/mypage/layout.tsx
+++ b/src/app/photographer/mypage/layout.tsx
@@ -1,0 +1,20 @@
+import Navbar from "@/containers/mypage/navbar";
+import styles from "@/styles/page.module.css";
+
+const MypageLayout = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) => {
+  return (
+    <div
+      className={styles.center}
+      style={{ display: "flex", flexDirection: "row" }}
+    >
+      <Navbar />
+      <div style={{ flex: 1 }}>{children}</div>
+    </div>
+  );
+};
+
+export default MypageLayout;

--- a/src/app/photographer/mypage/previous/page.tsx
+++ b/src/app/photographer/mypage/previous/page.tsx
@@ -1,0 +1,11 @@
+import Preparing from "@/containers/mypage/preparing";
+
+const MyPreviousPage = () => {
+  return (
+    <div>
+      <Preparing />
+    </div>
+  );
+};
+
+export default MyPreviousPage;

--- a/src/app/photographer/mypage/profile/page.tsx
+++ b/src/app/photographer/mypage/profile/page.tsx
@@ -1,0 +1,11 @@
+import Preparing from "@/containers/mypage/preparing";
+
+const MyProfilePage = () => {
+  return (
+    <div>
+      <Preparing />
+    </div>
+  );
+};
+
+export default MyProfilePage;

--- a/src/app/photographer/mypage/schedule/page.tsx
+++ b/src/app/photographer/mypage/schedule/page.tsx
@@ -1,0 +1,11 @@
+import Preparing from "@/containers/mypage/preparing";
+
+const MySchedulePage = () => {
+  return (
+    <div>
+      <Preparing />
+    </div>
+  );
+};
+
+export default MySchedulePage;

--- a/src/components/buttons/common-buttons.tsx
+++ b/src/components/buttons/common-buttons.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Link as LinkProp } from "profile-types";
+import { LinkType } from "profile-types";
 import * as style from "./buttons.css";
 import { Body15SB } from "../texts/texts";
 
@@ -24,10 +24,17 @@ export const SubmitButton = ({ onClick = () => {}, title }: ButtonProps) => {
   );
 };
 
-export const LinkButton = ({ name, src }: LinkProp) => {
+export const LinkButton = ({
+  name,
+  src,
+  selected = false,
+}: LinkType & { selected?: boolean }) => {
   return (
     <Link href={src}>
-      <div className={style.LinkContainer}>
+      <div
+        className={style.LinkContainer}
+        style={selected ? { backgroundColor: "#a9a9a9" } : {}}
+      >
         <Body15SB>{name}</Body15SB>
       </div>
     </Link>

--- a/src/containers/customer/main/info-sheet.tsx
+++ b/src/containers/customer/main/info-sheet.tsx
@@ -1,13 +1,13 @@
 import ServiceFooter from "@/components/customer/service-footer";
 import { LinkButton } from "@/components/buttons/common-buttons";
-import { Link } from "profile-types";
+import { LinkType } from "profile-types";
 import { buttonsWrapper, sheetContainer } from "./main.css";
 
 interface InfoSheetProps {
   id: string;
   // TODO: 소개글 최대 길이 제한
   message: string;
-  links: Link[];
+  links: LinkType[];
 }
 
 const InfoSheet = ({ id, links, message }: InfoSheetProps) => {

--- a/src/containers/main/header.tsx
+++ b/src/containers/main/header.tsx
@@ -9,7 +9,7 @@ const Header = () => {
 
   return (
     <header className={styles.headerContainer}>
-      <Link href="/">
+      <Link href="/photographer">
         <div>메인</div>
       </Link>
       <Profile name="ForU" />

--- a/src/containers/main/header.tsx
+++ b/src/containers/main/header.tsx
@@ -5,7 +5,7 @@ import Url from "./header/url";
 
 const Header = () => {
   // [TODO] 회원가입 후 api 요청과 연결
-  const myUrl = "https://www.freebe.co.kr/randid";
+  const myUrl = "https://www.freebe.co.kr/myid";
 
   return (
     <header className={styles.headerContainer}>

--- a/src/containers/main/header/profile.tsx
+++ b/src/containers/main/header/profile.tsx
@@ -5,7 +5,7 @@ import { profileContainer } from "./header.css";
 const Profile = ({ name }: { name: string }) => {
   return (
     <div className={profileContainer}>
-      <Link href="/mypage/products">마이페이지</Link>
+      <Link href="photographer/mypage/products">마이페이지</Link>
       <Body15SB>{name} 작가님</Body15SB>
     </div>
   );

--- a/src/containers/main/header/profile.tsx
+++ b/src/containers/main/header/profile.tsx
@@ -5,7 +5,7 @@ import { profileContainer } from "./header.css";
 const Profile = ({ name }: { name: string }) => {
   return (
     <div className={profileContainer}>
-      <Link href="photographer/mypage/products">마이페이지</Link>
+      <Link href="/photographer/mypage/products">마이페이지</Link>
       <Body15SB>{name} 작가님</Body15SB>
     </div>
   );

--- a/src/containers/mypage/mypage.css.ts
+++ b/src/containers/mypage/mypage.css.ts
@@ -1,0 +1,7 @@
+import { style } from "@vanilla-extract/css";
+
+export const navbarStyle = {
+  container: style({
+    alignSelf: "flex-start",
+  }),
+};

--- a/src/containers/mypage/navbar.tsx
+++ b/src/containers/mypage/navbar.tsx
@@ -1,0 +1,37 @@
+import { LinkButton } from "@/components/buttons/common-buttons";
+import { Link } from "profile-types";
+
+const Navbar = () => {
+  const mypageTabs: Link[] = [
+    {
+      name: "이전 예약",
+      src: "previous",
+    },
+    {
+      name: "내 상품 목록",
+      src: "products",
+    },
+    {
+      name: "내 프로필 관리",
+      src: "profile",
+    },
+    {
+      name: "자주 묻는 질문 관리",
+      src: "faqs",
+    },
+    {
+      name: "예약 일정 오픈",
+      src: "schedule",
+    },
+  ];
+
+  return (
+    <div>
+      {mypageTabs.map((tab, index) => (
+        <LinkButton key={index} {...tab} />
+      ))}
+    </div>
+  );
+};
+
+export default Navbar;

--- a/src/containers/mypage/navbar.tsx
+++ b/src/containers/mypage/navbar.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import { LinkButton } from "@/components/buttons/common-buttons";
-import { Link } from "profile-types";
+import { usePathname } from "next/navigation";
+import { LinkType } from "profile-types";
 
 const Navbar = () => {
-  const mypageTabs: Link[] = [
+  const currentTab = usePathname().split("/").pop();
+  const mypageTabs: LinkType[] = [
     {
       name: "이전 예약",
       src: "previous",
@@ -28,7 +32,7 @@ const Navbar = () => {
   return (
     <div>
       {mypageTabs.map((tab, index) => (
-        <LinkButton key={index} {...tab} />
+        <LinkButton key={index} selected={currentTab === tab.src} {...tab} />
       ))}
     </div>
   );

--- a/src/containers/mypage/navbar.tsx
+++ b/src/containers/mypage/navbar.tsx
@@ -3,6 +3,7 @@
 import { LinkButton } from "@/components/buttons/common-buttons";
 import { usePathname } from "next/navigation";
 import { LinkType } from "profile-types";
+import { navbarStyle } from "./mypage.css";
 
 const Navbar = () => {
   const currentTab = usePathname().split("/").pop();
@@ -30,7 +31,7 @@ const Navbar = () => {
   ];
 
   return (
-    <div>
+    <div className={navbarStyle.container}>
       {mypageTabs.map((tab, index) => (
         <LinkButton key={index} selected={currentTab === tab.src} {...tab} />
       ))}

--- a/src/containers/mypage/preparing.tsx
+++ b/src/containers/mypage/preparing.tsx
@@ -1,0 +1,11 @@
+import { Body15SB } from "@/components/texts/texts";
+
+const Preparing = () => {
+  return (
+    <div>
+      <Body15SB>준비 중인 서비스입니다. 조금만 기다려 주세요!</Body15SB>
+    </div>
+  );
+};
+
+export default Preparing;

--- a/src/containers/product/product-list.tsx
+++ b/src/containers/product/product-list.tsx
@@ -20,7 +20,9 @@ const ProductList = ({ productDatas, status }: ProductListProps) => {
     <div className={listDiv}>
       <div className={listHead}>
         <Body15SB>{titles[status]}</Body15SB>
-        {status === "ACTIVE" && <Link href="/new-product">추가</Link>}
+        {status === "ACTIVE" && (
+          <Link href="/photographer/new-product">추가</Link>
+        )}
       </div>
       <div className={listBody}>
         {productDatas.map((data) => (

--- a/src/types/profile-types.d.ts
+++ b/src/types/profile-types.d.ts
@@ -1,5 +1,5 @@
 declare module "profile-types" {
-  export interface Link {
+  export interface LinkType {
     src: string;
     name: string;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,8 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "./src/types",
-    "src/app/photographer/mypage/schedule"
+    "./src/types"
   ],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "./src/types"
+    "./src/types",
+    "src/app/photographer/mypage/schedule"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 작가측 mypage 공통 layout 구현
* side navbar 추가 및 페이지별 연결

## 고민한 사항
* **반응형 레이아웃 관련**
페이지에 min-width를 주어 화면이 최소 너비보다 작아질 경우 스크롤이 생기도록 처리하였으나, fixed로 고정되어 있는 작가측 헤더는 이 스크롤의 적용을 받지 못하는 상태입니다. 관련해서 방법을 조금 찾아보았을 때 스크롤 이벤트를 헤더에서 감지해 아래 화면이 움직이는 만큼 같이 이동하게 하는 안을 찾기는 했으나 지나치게 복잡한 방법이라고 느껴져서…! 🤔 모바일 뷰 디자인을 받아 본 뒤 헤더의 경우 별도로 반응형 디자인을 입히는 안을 고려 중입니다.

## 리뷰 요청사항
* 마이페이지의 탭별 path에 대해 코멘트가 있다면 남겨 주세요! 
현재 `/photographer/mypage`에서 이전 예약 `/previous`, 내 상품 목록 `/products`, 내 프로필 관리 `/profile`, 자주 묻는 질문 관리 `/faqs`, 예약 일정 오픈 `/schedule`로 연결
* 크게 복잡한 로직은 없었어서 가볍게 확인해 주셔도 괜찮을 것 같습니다 👍
* 시급도: 보통
마이페이지 관련된 다음 작업을 진행하기 전 리뷰 필요 

## 스크린샷
<img width="999" alt="스크린샷 2024-08-06 오후 2 26 48" src="https://github.com/user-attachments/assets/ad2008ee-b701-4500-bb9f-7058f57e06d5">
