### PR TITLE
[FU-204] cancel reservation

### DIFF
--- a/src/components/inputs/common-input.tsx
+++ b/src/components/inputs/common-input.tsx
@@ -1,0 +1,54 @@
+import { CSSProperties, DetailedHTMLProps, InputHTMLAttributes } from "react";
+import InputStyles from "./input.css";
+
+interface CommonInputProps
+  extends DetailedHTMLProps<
+    InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  > {
+  title?: string;
+  inputSize?: "sm" | "md";
+  placeholder?: string;
+  disabled?: boolean;
+  multiline?: boolean;
+  container?: CSSProperties;
+}
+
+const CommonInput = ({
+  title,
+  placeholder = "내용을 입력해주세요.",
+  disabled,
+  multiline,
+  container,
+  inputSize = "sm",
+  ...props
+}: CommonInputProps) => {
+  return (
+    <div className={InputStyles.container} style={container}>
+      {title && <span className={InputStyles.title}>{title}</span>}
+      <div
+        className={`${
+          disabled ? InputStyles.disabledInputWrapper : InputStyles.inputWrapper
+        } ${inputSize === "sm" ? InputStyles.smWrapper : InputStyles.mdWrapper}`}
+      >
+        {multiline ? (
+          <textarea
+            className={
+              disabled ? InputStyles.disabledInput : InputStyles.multilineInput
+            }
+            placeholder={placeholder}
+          />
+        ) : (
+          <input
+            className={disabled ? InputStyles.disabledInput : InputStyles.input}
+            placeholder={placeholder}
+            disabled={disabled}
+            {...props}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CommonInput;

--- a/src/constants/common/reservation.ts
+++ b/src/constants/common/reservation.ts
@@ -20,3 +20,12 @@ export const statusInfos: Record<Status, string> = {
   PHOTO_COMPLETED: "이미 완료된 촬영이에요.",
   CANCELLED: "취소된 촬영이에요.",
 };
+
+export const customerStatusInfos: Record<Status, string> = {
+  NEW: "신청서 제출이 완료되었습니다.",
+  IN_PROGRESS: "촬영 상담이 진행 중입니다.",
+  WAITING_FOR_DEPOSIT: "입금을 기다리는 중입니다.",
+  WAITING_FOR_PHOTO: "촬영 대기 중입니다. 즐거운 촬영 되세요!",
+  PHOTO_COMPLETED: "완료된 촬영입니다.",
+  CANCELLED: "취소된 촬영입니다.",
+};

--- a/src/containers/common/status/icon.tsx
+++ b/src/containers/common/status/icon.tsx
@@ -7,6 +7,7 @@ import { bannerStyles, iconStyles } from "./status.css";
 const Banner = ({
   status,
   current,
+  canceled,
 }: Omit<Parameters<typeof StatusIcon>[0], "date" | "hasInformation">) => {
   const statusIndex: Record<Status, string> = {
     NEW: "1",
@@ -22,7 +23,11 @@ const Banner = ({
       <div className={bannerStyles.wrapper}>
         {current === "DONE" && (
           <div className={bannerStyles.image}>
-            <Image src="/icons/components/check.svg" alt="check" fill />
+            {canceled ? (
+              <Image src="/icons/close-shadow.svg" alt="canceled" fill />
+            ) : (
+              <Image src="/icons/components/check.svg" alt="check" fill />
+            )}
           </div>
         )}
         {current === "NOW" && (
@@ -40,19 +45,21 @@ const StatusIcon = ({
   status,
   current,
   date,
+  canceled,
   hasInformation,
 }: {
   status: Status;
   hasInformation: boolean;
   current: "DONE" | "NOW" | "NOT_STARTED";
   date?: string;
+  canceled?: boolean;
 }) => {
   return (
     <div className={iconStyles.container}>
       <div className={iconStyles.wrapper}>
-        <span className={iconStyles.caption}>{date}</span>
+        <span className={iconStyles.caption}>{canceled ? "취소" : date}</span>
       </div>
-      <Banner status={status} current={current} />
+      <Banner status={status} current={current} canceled={canceled} />
       <div className={iconStyles.wrapper}>
         <span
           className={

--- a/src/containers/common/status/index.tsx
+++ b/src/containers/common/status/index.tsx
@@ -1,4 +1,4 @@
-import { StatusHistory } from "reservation-types";
+import { Status, StatusHistory } from "reservation-types";
 import Progress from "./progress";
 import { statusStyles } from "./status.css";
 import StatusIcon from "./icon";
@@ -6,37 +6,73 @@ import StatusIcon from "./icon";
 const ReservationStatus = ({
   statusHistory,
   noInformation = false,
+  cancelStatus,
 }: {
   statusHistory: StatusHistory;
   noInformation?: boolean;
+  cancelStatus?: Status;
 }) => {
   return (
     <div className={statusStyles.container}>
       <StatusIcon
         status="NEW"
+        canceled={cancelStatus === "NEW"}
         current={statusHistory.NEW.current}
         date={statusHistory.NEW.updatedDate || ""}
         hasInformation={!noInformation}
       />
-      <Progress current={statusHistory.NEW.current} />
+      <Progress
+        current={
+          cancelStatus === "NEW" ? "NOT_STARTED" : statusHistory.NEW.current
+        }
+      />
       <StatusIcon
+        canceled={cancelStatus === "IN_PROGRESS"}
         status="IN_PROGRESS"
         current={statusHistory.IN_PROGRESS.current}
         date={statusHistory.IN_PROGRESS.updatedDate || ""}
         hasInformation={!noInformation}
       />
-      <Progress current={statusHistory.IN_PROGRESS.current} />
+      <Progress
+        current={
+          cancelStatus === "IN_PROGRESS"
+            ? "NOT_STARTED"
+            : statusHistory.IN_PROGRESS.current
+        }
+      />
       <StatusIcon
+        canceled={cancelStatus === "WAITING_FOR_DEPOSIT"}
         status="WAITING_FOR_DEPOSIT"
         current={statusHistory.WAITING_FOR_DEPOSIT.current}
         date={statusHistory.WAITING_FOR_DEPOSIT.updatedDate || ""}
         hasInformation={!noInformation}
       />
-      <Progress current={statusHistory.WAITING_FOR_DEPOSIT.current} />
+      <Progress
+        current={
+          cancelStatus === "WAITING_FOR_DEPOSIT"
+            ? "NOT_STARTED"
+            : statusHistory.WAITING_FOR_DEPOSIT.current
+        }
+      />
       <StatusIcon
+        canceled={cancelStatus === "WAITING_FOR_PHOTO"}
         status="WAITING_FOR_PHOTO"
         current={statusHistory.WAITING_FOR_PHOTO.current}
         date={statusHistory.WAITING_FOR_PHOTO.updatedDate || ""}
+        hasInformation={!noInformation}
+      />
+      <Progress
+        current={
+          cancelStatus === "WAITING_FOR_PHOTO"
+            ? "NOT_STARTED"
+            : statusHistory.WAITING_FOR_PHOTO.current
+        }
+      />
+      <StatusIcon
+        canceled={cancelStatus === "PHOTO_COMPLETED"}
+        status="PHOTO_COMPLETED"
+        current={statusHistory.PHOTO_COMPLETED.current}
+        date={statusHistory.PHOTO_COMPLETED.updatedDate || ""}
         hasInformation={!noInformation}
       />
     </div>

--- a/src/containers/common/status/status.css.ts
+++ b/src/containers/common/status/status.css.ts
@@ -33,7 +33,7 @@ export const statusStyles = styleVariants({
         width: "100%",
         height: 120,
         maxWidth: "100%",
-        padding: "20px 20px",
+        padding: "20px 0px",
         gap: 10,
         background: "none",
       },

--- a/src/containers/customer/reservation/details/cancel-modal.tsx
+++ b/src/containers/customer/reservation/details/cancel-modal.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { Modal } from "@mantine/core";
+import { CustomButton } from "@/components/buttons/common-buttons";
+import CommonInput from "@/components/inputs/common-input";
+import popToast from "@/components/common/toast";
+import { modalStyles } from "@/containers/customer/products/products.css";
+import { cancelReservation } from "@/services/client/customer/reservation";
+import { cancelStyles } from "./detail.css";
+
+const CancelModal = ({
+  close,
+  opened,
+}: {
+  opened: boolean;
+  close: () => void;
+}) => {
+  const { reservationId } = useParams<{ reservationId: string }>();
+  const [cancellationReason, setCancellationReason] = useState("");
+
+  async function handleCancel() {
+    try {
+      await cancelReservation(parseInt(reservationId, 10), cancellationReason);
+      popToast("취소가 완료되었습니다.");
+    } catch (error) {
+      popToast("다시 시도해주세요.", "취소가 실패했습니다.");
+    }
+  }
+
+  return (
+    <Modal
+      centered
+      opened={opened}
+      onClose={close}
+      classNames={{ ...modalStyles }}
+    >
+      <div className={cancelStyles.title}>신청서를 정말 취소하시겠어요?</div>
+      <div className={cancelStyles.message}>
+        취소하실 경우 사유를 꼭 작성해 주세요.
+      </div>
+      <CommonInput
+        placeholder="취소 사유를 입력해 주세요."
+        value={cancellationReason}
+        onChange={(e) => setCancellationReason(e.currentTarget.value)}
+      />
+      <CustomButton
+        size="sm"
+        styleType="primary"
+        title="취소하기"
+        disabled={cancellationReason === ""}
+        onClick={handleCancel}
+      />
+    </Modal>
+  );
+};
+
+export default CancelModal;

--- a/src/containers/customer/reservation/details/detail.css.ts
+++ b/src/containers/customer/reservation/details/detail.css.ts
@@ -14,6 +14,12 @@ export const detailStyles = styleVariants({
   ],
   title: [texts["headline-02"], sprinkles({ color: "text-point" })],
   message: [texts["body-02"], sprinkles({ color: "text-03" })],
+  chips: {
+    display: "flex",
+    gap: 10,
+    marginTop: 24,
+    height: 30,
+  },
   body: [
     sprinkles({
       backgroundColor: "bg-lightgrey",
@@ -26,4 +32,9 @@ export const detailStyles = styleVariants({
       gap: 8,
     },
   ],
+});
+
+export const cancelStyles = styleVariants({
+  title: [texts["headline-02"], sprinkles({ color: "text-02" })],
+  message: [texts["headline-03"], sprinkles({ color: "text-point" })],
 });

--- a/src/containers/customer/reservation/details/infos/infos.css.ts
+++ b/src/containers/customer/reservation/details/infos/infos.css.ts
@@ -26,7 +26,9 @@ export const infoStyles = styleVariants({
   },
   schedule: {
     display: "flex",
-    gap: "1ch",
+    flexWrap: "wrap",
+    justifyContent: "flex-end",
+    columnGap: "1ch",
   },
   title: [texts["headline-02"], sprinkles({ color: "text-02" })],
   name: [

--- a/src/containers/customer/reservation/details/status.tsx
+++ b/src/containers/customer/reservation/details/status.tsx
@@ -2,10 +2,12 @@
 
 import { usePathname } from "next/navigation";
 import { CustomerDetails, StatusHistory } from "reservation-types";
+import { useDisclosure } from "@mantine/hooks";
 import ReservationStatus from "@/containers/common/status";
-import { compareStatus } from "@/utils/reservation";
+import { compareStatus, isCustomerAbleToCancel } from "@/utils/reservation";
 import Chip from "@/components/common/chip";
 import popToast from "@/components/common/toast";
+import CancelModal from "./cancel-modal";
 import { detailStyles } from "./detail.css";
 
 const Status = ({
@@ -13,6 +15,7 @@ const Status = ({
   currentStatus,
 }: Pick<CustomerDetails, "productTitle" | "currentStatus">) => {
   const url = usePathname();
+  const [opened, { close, open }] = useDisclosure(false);
 
   const statusHistory: StatusHistory = {
     NEW: {
@@ -48,12 +51,13 @@ const Status = ({
         신청서 제출이 완료되었습니다.
       </span>
       <ReservationStatus statusHistory={statusHistory} noInformation />
-      <Chip
-        name="공유하기"
-        container={{ marginTop: 24, height: 30 }}
-        styleType="highlight"
-        onClick={handleExport}
-      />
+      <div className={detailStyles.chips}>
+        <Chip name="공유하기" styleType="highlight" onClick={handleExport} />
+        {isCustomerAbleToCancel(currentStatus) && (
+          <Chip name="취소하기" styleType="highlight" onClick={open} />
+        )}
+      </div>
+      <CancelModal close={close} opened={opened} />
     </div>
   );
 };

--- a/src/containers/customer/reservation/details/status.tsx
+++ b/src/containers/customer/reservation/details/status.tsx
@@ -5,6 +5,7 @@ import { CustomerDetails, StatusHistory } from "reservation-types";
 import { useDisclosure } from "@mantine/hooks";
 import ReservationStatus from "@/containers/common/status";
 import { compareStatus, isCustomerAbleToCancel } from "@/utils/reservation";
+import { customerStatusInfos } from "@/constants/common/reservation";
 import Chip from "@/components/common/chip";
 import popToast from "@/components/common/toast";
 import CancelModal from "./cancel-modal";
@@ -30,6 +31,12 @@ const Status = ({
     WAITING_FOR_PHOTO: {
       current: compareStatus(currentStatus, "WAITING_FOR_PHOTO"),
     },
+    PHOTO_COMPLETED: {
+      current: compareStatus(currentStatus, "PHOTO_COMPLETED"),
+    },
+    CANCELLED: {
+      current: compareStatus(currentStatus, "CANCELLED"),
+    },
   };
 
   async function handleExport() {
@@ -48,9 +55,11 @@ const Status = ({
     <div className={detailStyles.container}>
       <span className={detailStyles.title}>{productTitle}</span>
       <span className={detailStyles.message}>
-        신청서 제출이 완료되었습니다.
+        {customerStatusInfos[currentStatus]}
       </span>
-      <ReservationStatus statusHistory={statusHistory} noInformation />
+      {currentStatus !== "CANCELLED" && (
+        <ReservationStatus statusHistory={statusHistory} noInformation />
+      )}
       <div className={detailStyles.chips}>
         <Chip name="공유하기" styleType="highlight" onClick={handleExport} />
         {isCustomerAbleToCancel(currentStatus) && (

--- a/src/containers/photographer/reservation/index.tsx
+++ b/src/containers/photographer/reservation/index.tsx
@@ -15,7 +15,10 @@ const ReservationDetailsPage = ({ detailsData }: { detailsData: Details }) => {
     <FormProvider {...method}>
       <div className={containerStyle}>
         <div className={detailStyle}>
-          <ReservationStatus {...detailsData} />
+          <ReservationStatus
+            {...detailsData}
+            // cancelStatus="WAITING_FOR_PHOTO"
+          />
           <ReservationTitle {...detailsData} />
           <ReservationDetails />
         </div>

--- a/src/containers/photographer/reservation/index.tsx
+++ b/src/containers/photographer/reservation/index.tsx
@@ -15,10 +15,7 @@ const ReservationDetailsPage = ({ detailsData }: { detailsData: Details }) => {
     <FormProvider {...method}>
       <div className={containerStyle}>
         <div className={detailStyle}>
-          <ReservationStatus
-            {...detailsData}
-            // cancelStatus="WAITING_FOR_PHOTO"
-          />
+          <ReservationStatus {...detailsData} />
           <ReservationTitle {...detailsData} />
           <ReservationDetails />
         </div>

--- a/src/containers/photographer/reservation/section/control/cancel-modal.tsx
+++ b/src/containers/photographer/reservation/section/control/cancel-modal.tsx
@@ -41,7 +41,7 @@ const CancelModal = ({
         onClick={() =>
           putReservationStatus(
             parseInt(reservationId, 10),
-            "CANCELLED",
+            "CANCELLED_BY_PHOTOGRAPHER",
             cancellationReason,
           )
         }

--- a/src/services/client/customer/reservation.ts
+++ b/src/services/client/customer/reservation.ts
@@ -51,3 +51,18 @@ export async function postReservation(
   const { data } = response;
   return data;
 }
+
+export async function cancelReservation(
+  id: number,
+  cancellationReason: string,
+) {
+  const body = {
+    cancellationReason,
+  };
+  const response = await apiClient.put(`customer/reservation/${id}`, {
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error();
+  }
+}

--- a/src/services/client/photographer/reservations.ts
+++ b/src/services/client/photographer/reservations.ts
@@ -27,7 +27,7 @@ export async function getReservationList() {
 
 export async function putReservationStatus(
   id: number,
-  targetStatus: Status,
+  targetStatus: Status | "CANCELLED_BY_PHOTOGRAPHER",
   cancel?: string,
 ) {
   const body = {

--- a/src/services/server/customer/reservation.ts
+++ b/src/services/server/customer/reservation.ts
@@ -65,19 +65,67 @@ export async function getImageList(photographerId: string) {
   return data;
 }
 
+const dummyData: CustomerReservationResponse = {
+  reservationStatus: "PHOTO_COMPLETED",
+  productTitle: "우정스냅",
+  photoInfo: {
+    "기본 가격": "160,000",
+    "촬영 장소": "테이프콜 스튜디오",
+    "상품 구성": "보정본 4장 + 네컷 or ID카드 3종 + 원본 전체",
+  },
+  preferredDate: {
+    "1": {
+      date: "2024-09-01",
+      startTime: "15:00:00",
+      endTime: "17:00:00",
+    },
+    "2": {
+      date: "2024-09-01",
+      startTime: "15:00:00",
+      endTime: "17:00:00",
+    },
+    "3": {
+      date: "2024-09-01",
+      startTime: "15:00:00",
+      endTime: "17:00:00",
+    },
+  },
+  photoOptions: {
+    "1": {
+      title: "인원 추가",
+      quantity: 1,
+      price: 30000,
+    },
+    "2": {
+      title: "착장 추가",
+      quantity: 2,
+      price: 40000,
+    },
+  },
+  customerMemo: "history 테이블 업데이트 후 새 신청서2!",
+};
+
 export async function getReservationDetails(
   reservationId: number,
 ): Promise<CustomerDetails> {
-  const { data } = await api
-    .get(`customer/reservation/${reservationId}`)
-    .json<{ data: CustomerReservationResponse }>();
+  // const { data } = await api
+  //   .get(`customer/reservation/${reservationId}`)
+  //   .json<{ data: CustomerReservationResponse }>();
+
+  const data = dummyData as CustomerReservationResponse;
   const options = objectToArray(data.photoOptions, (arr) =>
     arr.map(([_, content]) => content),
   ) as OptionDetails[];
+  const currentStatus =
+    data.reservationStatus === "CANCELLED_BY_CUSTOMER" ||
+    data.reservationStatus === "CANCELLED_BY_PHOTOGRAPHER"
+      ? "CANCELLED"
+      : data.reservationStatus;
+
   return {
     ...data,
     options,
-    currentStatus: data.reservationStatus,
+    currentStatus,
     preferredDates: objectToArray(data.preferredDate, (arr) =>
       arr.sort().map(([_, content]) => content),
     ),

--- a/src/services/server/customer/reservation.ts
+++ b/src/services/server/customer/reservation.ts
@@ -65,54 +65,13 @@ export async function getImageList(photographerId: string) {
   return data;
 }
 
-const dummyData: CustomerReservationResponse = {
-  reservationStatus: "PHOTO_COMPLETED",
-  productTitle: "우정스냅",
-  photoInfo: {
-    "기본 가격": "160,000",
-    "촬영 장소": "테이프콜 스튜디오",
-    "상품 구성": "보정본 4장 + 네컷 or ID카드 3종 + 원본 전체",
-  },
-  preferredDate: {
-    "1": {
-      date: "2024-09-01",
-      startTime: "15:00:00",
-      endTime: "17:00:00",
-    },
-    "2": {
-      date: "2024-09-01",
-      startTime: "15:00:00",
-      endTime: "17:00:00",
-    },
-    "3": {
-      date: "2024-09-01",
-      startTime: "15:00:00",
-      endTime: "17:00:00",
-    },
-  },
-  photoOptions: {
-    "1": {
-      title: "인원 추가",
-      quantity: 1,
-      price: 30000,
-    },
-    "2": {
-      title: "착장 추가",
-      quantity: 2,
-      price: 40000,
-    },
-  },
-  customerMemo: "history 테이블 업데이트 후 새 신청서2!",
-};
-
 export async function getReservationDetails(
   reservationId: number,
 ): Promise<CustomerDetails> {
-  // const { data } = await api
-  //   .get(`customer/reservation/${reservationId}`)
-  //   .json<{ data: CustomerReservationResponse }>();
+  const { data } = await api
+    .get(`customer/reservation/${reservationId}`)
+    .json<{ data: CustomerReservationResponse }>();
 
-  const data = dummyData as CustomerReservationResponse;
   const options = objectToArray(data.photoOptions, (arr) =>
     arr.map(([_, content]) => content),
   ) as OptionDetails[];

--- a/src/services/server/photographer/reservation.ts
+++ b/src/services/server/photographer/reservation.ts
@@ -2,13 +2,87 @@ import { Details, ReservationDetailResponse } from "reservation-types";
 import { objectToArray } from "@/utils/parse";
 import { api } from "../core";
 
+const dummyData: ReservationDetailResponse = {
+  reservationNumber: 22,
+  currentReservationStatus: "CANCELLED_BY_CUSTOMER",
+  statusBeforeCancellation: "WAITING_FOR_DEPOSIT",
+  statusHistory: [
+    {
+      reservationStatus: "NEW",
+      statusUpdateDate: "2024-09-04",
+    },
+    {
+      reservationStatus: "IN_PROGRESS",
+      statusUpdateDate: "2024-09-04",
+    },
+    {
+      reservationStatus: "WAITING_FOR_DEPOSIT",
+      statusUpdateDate: "2024-09-04",
+    },
+    // {
+    //   reservationStatus: "WAITING_FOR_PHOTO",
+    //   statusUpdateDate: "2024-09-04",
+    // },
+    {
+      reservationStatus: "CANCELLED_BY_CUSTOMER",
+      statusUpdateDate: "2024-09-04",
+    },
+  ],
+  productTitle: "웨딩스냅1",
+  customerDetails: {
+    name: "이유리",
+    phoneNumber: "010-7554-3789",
+    instagramId: "example_insta_id",
+  },
+  photoInfo: {
+    "기본 가격": "160,000",
+    "촬영 장소": "테이프콜 스튜디오",
+    "상품 구성": "보정본 4장 + 네컷 or ID카드 3종 + 원본 전체",
+  },
+  photoOptions: {
+    "1": {
+      title: "인원 추가",
+      quantity: 1,
+      price: 30000,
+    },
+    "2": {
+      title: "착장 추가",
+      quantity: 2,
+      price: 40000,
+    },
+  },
+  preferredDates: {
+    "1": {
+      date: "2024-09-01",
+      startTime: "15:00:00",
+      endTime: "17:00:00",
+    },
+    "2": {
+      date: "2024-09-01",
+      startTime: "15:00:00",
+      endTime: "17:00:00",
+    },
+    "3": {
+      date: "2024-09-01",
+      startTime: "15:00:00",
+      endTime: "17:00:00",
+    },
+  },
+  originalImage: ["", ""],
+  thumbnailImage: ["", ""],
+  requestMemo: "예쁘게 찍어주세요",
+  photographerMemo: null,
+};
+
 export async function getReservationDetail(
   reservationId: number,
 ): Promise<Details> {
-  const response = await api.get(
-    `photographer/reservation/details/${reservationId}`,
-  );
-  const { data } = await response.json<{ data: ReservationDetailResponse }>();
+  // const response = await api.get(
+  //   `photographer/reservation/details/${reservationId}`,
+  // );
+  // const { data } = await response.json<{ data: ReservationDetailResponse }>();
+
+  const data = dummyData as ReservationDetailResponse;
 
   const { statusHistory }: Pick<Details, "statusHistory"> = {
     statusHistory: {
@@ -16,20 +90,40 @@ export async function getReservationDetail(
       IN_PROGRESS: { updatedDate: null, current: "NOT_STARTED" },
       WAITING_FOR_DEPOSIT: { updatedDate: null, current: "NOT_STARTED" },
       WAITING_FOR_PHOTO: { updatedDate: null, current: "NOT_STARTED" },
+      PHOTO_COMPLETED: { updatedDate: null, current: "NOT_STARTED" },
+      CANCELLED: { updatedDate: null, current: "NOT_STARTED" },
     },
   };
+
   data.statusHistory.forEach((history) => {
-    statusHistory[history.reservationStatus].updatedDate =
-      history.statusUpdateDate;
-    statusHistory[history.reservationStatus].current =
-      data.currentReservationStatus === history.reservationStatus
-        ? "NOW"
-        : "DONE";
+    if (
+      history.reservationStatus === "CANCELLED_BY_CUSTOMER" ||
+      history.reservationStatus === "CANCELLED_BY_PHOTOGRAPHER"
+    ) {
+      statusHistory.CANCELLED.updatedDate = history.statusUpdateDate;
+      statusHistory.CANCELLED.current = "NOW";
+    } else {
+      statusHistory[history.reservationStatus].updatedDate =
+        history.statusUpdateDate;
+      statusHistory[history.reservationStatus].current =
+        data.currentReservationStatus !== "PHOTO_COMPLETED" &&
+        data.currentReservationStatus === history.reservationStatus
+          ? "NOW"
+          : "DONE";
+    }
   });
+
+  const currentStatus =
+    data.currentReservationStatus === "CANCELLED_BY_CUSTOMER" ||
+    data.currentReservationStatus === "CANCELLED_BY_PHOTOGRAPHER"
+      ? "CANCELLED"
+      : data.currentReservationStatus;
+
   return {
     ...data,
     statusHistory,
-    currentStatus: data.currentReservationStatus,
+    currentStatus,
+    cancelStatus: data.statusBeforeCancellation,
     customer: data.customerDetails,
     photographerMemo: data.photographerMemo || "",
     productInfo: objectToArray(data.photoInfo, (arr) =>

--- a/src/services/server/photographer/reservation.ts
+++ b/src/services/server/photographer/reservation.ts
@@ -2,87 +2,13 @@ import { Details, ReservationDetailResponse } from "reservation-types";
 import { objectToArray } from "@/utils/parse";
 import { api } from "../core";
 
-const dummyData: ReservationDetailResponse = {
-  reservationNumber: 22,
-  currentReservationStatus: "CANCELLED_BY_CUSTOMER",
-  statusBeforeCancellation: "WAITING_FOR_DEPOSIT",
-  statusHistory: [
-    {
-      reservationStatus: "NEW",
-      statusUpdateDate: "2024-09-04",
-    },
-    {
-      reservationStatus: "IN_PROGRESS",
-      statusUpdateDate: "2024-09-04",
-    },
-    {
-      reservationStatus: "WAITING_FOR_DEPOSIT",
-      statusUpdateDate: "2024-09-04",
-    },
-    // {
-    //   reservationStatus: "WAITING_FOR_PHOTO",
-    //   statusUpdateDate: "2024-09-04",
-    // },
-    {
-      reservationStatus: "CANCELLED_BY_CUSTOMER",
-      statusUpdateDate: "2024-09-04",
-    },
-  ],
-  productTitle: "웨딩스냅1",
-  customerDetails: {
-    name: "이유리",
-    phoneNumber: "010-7554-3789",
-    instagramId: "example_insta_id",
-  },
-  photoInfo: {
-    "기본 가격": "160,000",
-    "촬영 장소": "테이프콜 스튜디오",
-    "상품 구성": "보정본 4장 + 네컷 or ID카드 3종 + 원본 전체",
-  },
-  photoOptions: {
-    "1": {
-      title: "인원 추가",
-      quantity: 1,
-      price: 30000,
-    },
-    "2": {
-      title: "착장 추가",
-      quantity: 2,
-      price: 40000,
-    },
-  },
-  preferredDates: {
-    "1": {
-      date: "2024-09-01",
-      startTime: "15:00:00",
-      endTime: "17:00:00",
-    },
-    "2": {
-      date: "2024-09-01",
-      startTime: "15:00:00",
-      endTime: "17:00:00",
-    },
-    "3": {
-      date: "2024-09-01",
-      startTime: "15:00:00",
-      endTime: "17:00:00",
-    },
-  },
-  originalImage: ["", ""],
-  thumbnailImage: ["", ""],
-  requestMemo: "예쁘게 찍어주세요",
-  photographerMemo: null,
-};
-
 export async function getReservationDetail(
   reservationId: number,
 ): Promise<Details> {
-  // const response = await api.get(
-  //   `photographer/reservation/details/${reservationId}`,
-  // );
-  // const { data } = await response.json<{ data: ReservationDetailResponse }>();
-
-  const data = dummyData as ReservationDetailResponse;
+  const response = await api.get(
+    `photographer/reservation/details/${reservationId}`,
+  );
+  const { data } = await response.json<{ data: ReservationDetailResponse }>();
 
   const { statusHistory }: Pick<Details, "statusHistory"> = {
     statusHistory: {

--- a/src/types/reservation-types.d.ts
+++ b/src/types/reservation-types.d.ts
@@ -23,6 +23,7 @@ declare module "reservation-types" {
 
   interface BaseDetails {
     currentStatus: Status;
+    cancelStatus?: Status;
     productTitle: string;
     productInfo: { title: string; content: string }[];
     preferredDates: ReservationDate[];
@@ -32,6 +33,7 @@ declare module "reservation-types" {
 
   interface BaseReservationResponse {
     productTitle: string;
+    statusBeforeCancellation?: Status;
     photoInfo: { [key: string]: string };
     photoOptions: { [key: string]: Option };
   }
@@ -67,7 +69,7 @@ declare module "reservation-types" {
   }
 
   type StatusHistory = {
-    [key in ActiveStatus]: {
+    [key in Status]: {
       updatedDate?: string | null;
       current: "DONE" | "NOW" | "NOT_STARTED";
     };
@@ -75,14 +77,23 @@ declare module "reservation-types" {
 
   interface CustomerReservationResponse extends BaseReservationResponse {
     preferredDate: { [key: string]: ReservationDate };
-    reservationStatus: Status;
+    reservationStatus:
+      | Status
+      | "CANCELLED_BY_PHOTOGRAPHER"
+      | "CANCELLED_BY_CUSTOMER";
     customerMemo: string;
   }
   interface ReservationDetailResponse extends BaseReservationResponse {
     reservationNumber: number;
-    currentReservationStatus: Status;
+    currentReservationStatus:
+      | Status
+      | "CANCELLED_BY_PHOTOGRAPHER"
+      | "CANCELLED_BY_CUSTOMER";
     statusHistory: {
-      reservationStatus: ActiveStatus;
+      reservationStatus:
+        | Status
+        | "CANCELLED_BY_PHOTOGRAPHER"
+        | "CANCELLED_BY_CUSTOMER";
       statusUpdateDate: string;
     }[];
     customerDetails: {

--- a/src/utils/reservation.ts
+++ b/src/utils/reservation.ts
@@ -35,3 +35,7 @@ export function compareStatus(currentStatus: Status, targetStatus: Status) {
   }
   return "NOW";
 }
+
+export function isCustomerAbleToCancel(currentStatus: Status) {
+  return currentStatus === "NEW";
+}


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 사진의뢰자측 신청 취소 기능 추가
* 신청서 상태 관련 수정사항 반영

## 고민한 사항
* 신청 취소 상태에 대한 처리
-프론트에서는 취소 상태를 나누지는 않고, Response에서 취소 상태가 들어왔을 경우 프론트쪽 취소 상태값으로 변경하는 방식을 취했습니다. 현재는 취소 당사자 / 취소 사유를 보여 주는 기능이 없어 여기까지만 진행했고, 추가될 경우 누가 / 왜 취소했는지에 대해서는 별도 필드로 관리하게 될 것 같습니다!
-취소된 신청서의 경우 현재 상태 컴포넌트에서 어떻게 보여줘야 할지 고민이 있었습니다. 기존 statusHistory를 통해 프론트에서 '취소 전 마지막 상태'를 파악하기는 어려운 상태였는데, 작가측의 경우 백엔드에서 해당 정보를 응답에 포함시키는 쪽으로 수정해 줘서 해결되었습니다 (@rheeri 금방 반영해 줘서 고맙습니다 🥹💗)
-의뢰자측의 경우 신청서 상세 조회시 현상태만을 반환받고 있어, 우선은 취소 상태일 경우 상태바 컴포넌트를 보여 주지 않고 안내 메시지만 수정되게 처리했습니다. 

## 리뷰 요청사항
* 시급도: `보통`
다음 작업할 티켓이 신청서 관련이긴 한데 😅 일단은 작업 진행하고 있을 수 있을 것 같습니다! 

* `src/types/reservation-types.d.ts`에 정의된 `BaseReservationResponse (공통 필드)`, `CustomerReservationResponse`, `PhotographerReservationResponse`가 api 응답으로 들어오는 값의 타입을 제대로 받고 있는지 확인 부탁드립니다! 🙇 (+ 같은 파일에 정의된 `BaseDetails`, `CustomerDetails`, `PhotographerDetails`는 프론트 컴포넌트에서 사용되는 타입 구조이며, `src/services/server/customer/reservation.ts`, `src/services/server/photographer/reservation.ts`에서 각각 의뢰자측 / 사진작가측 신청서 상세 조회 후 해당 타입으로 변환하고 있습니다.) 

* 의뢰자측 신청 취소 api 요청은 `src/services/client/customer/reservation.ts`에 정의되어 있습니다. 취소 버튼은 '새 신청' 상태일 때만 보이도록 만들어 두었습니다!

* 상태별로 테스트를 진행하느라 신청서 상세 조회 결과로 더미 데이터를 끼워 뒀는데 머지 전에 수정 예정입니다! 참고 부탁드립니당

## 스크린샷
![스크린샷 2024-09-19 오후 5 10 28](https://github.com/user-attachments/assets/29ad8080-2417-4787-bec7-a2f29a401dff)

