### PR TITLE
[FU-222] fix: multipart/form-data request

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,7 +5,12 @@ const withVanillaExtract = createVanillaExtractPlugin();
 const nextConfig = {
   images: {
     // TODO: 이미지 허용 도메인 정리하기
-    domains: ["picsum.photos", "example.com", "search.pstatic.net"],
+    domains: [
+      "picsum.photos",
+      "example.com",
+      "search.pstatic.net",
+      "cicd-backend-develop-bucket.s3.ap-northeast-2.amazonaws.com",
+    ],
   },
   reactStrictMode: false,
   webpack: (config) => {

--- a/src/containers/photographer/join/index.tsx
+++ b/src/containers/photographer/join/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -55,7 +55,7 @@ const PhotographerJoin = () => {
         onSubmit={handleSubmit(onSubmit)}
         encType="multipart/form-data"
       >
-        <Profile profileImg={profileImg} setProfileImg={setProfileImg} />
+        <Profile setProfileImg={setProfileImg} />
         <Agreements />
         <CustomButton
           type="submit"

--- a/src/containers/photographer/join/index.tsx
+++ b/src/containers/photographer/join/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -31,6 +32,7 @@ const PhotographerJoin = () => {
     resolver: zodResolver(joinSchema),
   });
   const { handleSubmit, watch } = method;
+  const [profileImg, setProfileImg] = useState<File>();
   const [serviceAgreement, privacyAgreement] = watch([
     "serviceAgreement",
     "privacyAgreement",
@@ -38,7 +40,7 @@ const PhotographerJoin = () => {
 
   async function onSubmit(data: Join) {
     try {
-      const url = await postProfile(data);
+      const url = await postProfile(data, profileImg);
       popToast("가입이 완료되었습니다!", "");
       router.push(`/photographer?url=${url}`);
     } catch (error) {
@@ -48,8 +50,12 @@ const PhotographerJoin = () => {
 
   return (
     <FormProvider {...method}>
-      <form className={joinStyles.container} onSubmit={handleSubmit(onSubmit)}>
-        <Profile />
+      <form
+        className={joinStyles.container}
+        onSubmit={handleSubmit(onSubmit)}
+        encType="multipart/form-data"
+      >
+        <Profile profileImg={profileImg} setProfileImg={setProfileImg} />
         <Agreements />
         <CustomButton
           type="submit"

--- a/src/containers/photographer/join/profile.tsx
+++ b/src/containers/photographer/join/profile.tsx
@@ -1,10 +1,4 @@
-import {
-  ChangeEvent,
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useState,
-} from "react";
+import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { Join } from "profile-types";
 import ProfileImage from "@/components/images/profile-image";
@@ -13,16 +7,11 @@ import { CustomButton } from "@/components/buttons/common-buttons";
 import { profileStyles } from "./join.css";
 
 const Profile = ({
-  profileImg,
   setProfileImg,
 }: {
-  profileImg: File | undefined;
   setProfileImg: Dispatch<SetStateAction<File | undefined>>;
 }) => {
   const {
-    setValue,
-    watch,
-    register,
     formState: { errors },
   } = useFormContext<Join>();
   const [preview, setPreview] = useState<undefined | string>();

--- a/src/containers/photographer/join/profile.tsx
+++ b/src/containers/photographer/join/profile.tsx
@@ -1,4 +1,10 @@
-import { ChangeEvent, useState } from "react";
+import {
+  ChangeEvent,
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useState,
+} from "react";
 import { useFormContext } from "react-hook-form";
 import { Join } from "profile-types";
 import ProfileImage from "@/components/images/profile-image";
@@ -6,19 +12,25 @@ import TextInput from "@/components/inputs/text-input";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import { profileStyles } from "./join.css";
 
-const Profile = () => {
+const Profile = ({
+  profileImg,
+  setProfileImg,
+}: {
+  profileImg: File | undefined;
+  setProfileImg: Dispatch<SetStateAction<File | undefined>>;
+}) => {
   const {
     setValue,
     watch,
+    register,
     formState: { errors },
   } = useFormContext<Join>();
   const [preview, setPreview] = useState<undefined | string>();
-  const profileImg = watch("profileImg");
 
   function handleChangeProfileImg(e: ChangeEvent<HTMLInputElement>) {
     if (e.currentTarget.files) {
       const newFile = e.currentTarget.files[0];
-      setValue("profileImg", newFile);
+      setProfileImg(newFile);
       const blob = URL.createObjectURL(newFile);
       setPreview(blob);
       e.currentTarget.value = "";
@@ -26,7 +38,7 @@ const Profile = () => {
   }
 
   function handleDeleteProfileImg() {
-    setValue("profileImg", undefined);
+    setProfileImg(undefined);
     setPreview(undefined);
   }
 

--- a/src/containers/photographer/mypage/profile/edit/banner.tsx
+++ b/src/containers/photographer/mypage/profile/edit/banner.tsx
@@ -1,21 +1,25 @@
-import { ChangeEvent } from "react";
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { useFormContext } from "react-hook-form";
 import { Photographer } from "profile-types";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import { editStyles } from "./edit.css";
 
-const Banner = () => {
-  const { setValue, register } = useFormContext<Photographer>();
+const Banner = ({
+  setBannerFile,
+}: {
+  setBannerFile: Dispatch<SetStateAction<File | undefined>>;
+}) => {
+  const { setValue } = useFormContext<Photographer>();
 
   function handleDeleteBanner() {
-    setValue("bannerFile", undefined);
+    setBannerFile(undefined);
     setValue("banner", undefined);
   }
 
   function handleChangeBanner(e: ChangeEvent<HTMLInputElement>) {
     if (e.currentTarget.files) {
       const newFile = e.currentTarget.files[0];
-      setValue("bannerFile", newFile);
+      setBannerFile(newFile);
       const blob = URL.createObjectURL(newFile);
       setValue("banner", blob);
     }
@@ -44,7 +48,6 @@ const Banner = () => {
               right: 0,
               cursor: "pointer",
             }}
-            {...register("bannerFile")}
             onChange={handleChangeBanner}
           />
         </CustomButton>

--- a/src/containers/photographer/mypage/profile/edit/banner.tsx
+++ b/src/containers/photographer/mypage/profile/edit/banner.tsx
@@ -5,7 +5,7 @@ import { CustomButton } from "@/components/buttons/common-buttons";
 import { editStyles } from "./edit.css";
 
 const Banner = () => {
-  const { setValue } = useFormContext<Photographer>();
+  const { setValue, register } = useFormContext<Photographer>();
 
   function handleDeleteBanner() {
     setValue("bannerFile", undefined);
@@ -44,6 +44,7 @@ const Banner = () => {
               right: 0,
               cursor: "pointer",
             }}
+            {...register("bannerFile")}
             onChange={handleChangeBanner}
           />
         </CustomButton>

--- a/src/containers/photographer/mypage/profile/edit/basic-info.tsx
+++ b/src/containers/photographer/mypage/profile/edit/basic-info.tsx
@@ -7,8 +7,8 @@ import { CustomButton } from "@/components/buttons/common-buttons";
 import { editStyles } from "./edit.css";
 
 const BasicInfo = () => {
-  const { watch, setValue } = useFormContext<Photographer>();
-  const [profileImage] = watch(["profileImg", "imgFile"]);
+  const { watch, setValue, register } = useFormContext<Photographer>();
+  const [profileImage] = watch(["profileImg"]);
 
   function handleChangeProfileImg(e: ChangeEvent<HTMLInputElement>) {
     if (e.currentTarget.files) {
@@ -36,6 +36,7 @@ const BasicInfo = () => {
               right: 0,
               cursor: "pointer",
             }}
+            {...register("imgFile")}
             onChange={handleChangeProfileImg}
           />
         </CustomButton>

--- a/src/containers/photographer/mypage/profile/edit/basic-info.tsx
+++ b/src/containers/photographer/mypage/profile/edit/basic-info.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { useFormContext } from "react-hook-form";
 import { Photographer } from "profile-types";
 import TextInput from "@/components/inputs/text-input";
@@ -6,14 +6,18 @@ import ProfileImage from "@/components/images/profile-image";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import { editStyles } from "./edit.css";
 
-const BasicInfo = () => {
-  const { watch, setValue, register } = useFormContext<Photographer>();
+const BasicInfo = ({
+  setProfileFile,
+}: {
+  setProfileFile: Dispatch<SetStateAction<File | undefined>>;
+}) => {
+  const { watch, setValue } = useFormContext<Photographer>();
   const [profileImage] = watch(["profileImg"]);
 
   function handleChangeProfileImg(e: ChangeEvent<HTMLInputElement>) {
     if (e.currentTarget.files) {
       const newFile = e.currentTarget.files[0];
-      setValue("imgFile", newFile);
+      setProfileFile(newFile);
       const blob = URL.createObjectURL(newFile);
       setValue("profileImg", blob);
     }
@@ -36,7 +40,6 @@ const BasicInfo = () => {
               right: 0,
               cursor: "pointer",
             }}
-            {...register("imgFile")}
             onChange={handleChangeProfileImg}
           />
         </CustomButton>

--- a/src/containers/photographer/mypage/profile/edit/index.tsx
+++ b/src/containers/photographer/mypage/profile/edit/index.tsx
@@ -1,14 +1,21 @@
+import { Dispatch, SetStateAction } from "react";
 import Banner from "./banner";
 import BasicInfo from "./basic-info";
 import { editStyles } from "./edit.css";
 import Links from "./links";
 
-const ProfileEdit = () => {
+const ProfileEdit = ({
+  setBannerFile,
+  setProfileFile,
+}: {
+  setBannerFile: Dispatch<SetStateAction<File | undefined>>;
+  setProfileFile: Dispatch<SetStateAction<File | undefined>>;
+}) => {
   return (
     <div className={editStyles.container}>
       <div className={editStyles.wrapper}>
-        <BasicInfo />
-        <Banner />
+        <BasicInfo setProfileFile={setProfileFile} />
+        <Banner setBannerFile={setBannerFile} />
       </div>
       <Links />
     </div>

--- a/src/containers/photographer/mypage/profile/index.tsx
+++ b/src/containers/photographer/mypage/profile/index.tsx
@@ -37,14 +37,17 @@ const MyProfile = ({ profile }: { profile: Photographer }) => {
 
   return (
     <FormProvider {...method}>
-      <form onSubmit={handleSubmit(onSubmit)} className={profileStyles.form}>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className={profileStyles.form}
+        encType="multipart/form-data"
+      >
         <div className={profileStyles.container}>
           <Preview />
           <ProfileEdit />
         </div>
         <SubmitProfile />
       </form>
-      {/* <BottomButton title="프로필 저장" /> */}
     </FormProvider>
   );
 };

--- a/src/containers/photographer/mypage/profile/index.tsx
+++ b/src/containers/photographer/mypage/profile/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Photographer } from "profile-types";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -21,14 +22,16 @@ const MyProfile = ({ profile }: { profile: Photographer }) => {
     ),
   });
   const method = useForm<Photographer>({
-    defaultValues: profile,
+    defaultValues: { ...profile },
     resolver: zodResolver(profileSchema),
   });
   const { handleSubmit } = method;
+  const [profileFile, setProfileFile] = useState<File>();
+  const [bannerFile, setBannerFile] = useState<File>();
 
   const onSubmit: SubmitHandler<Photographer> = async (data) => {
     try {
-      await putProfile(data);
+      await putProfile(data, { bannerFile, profileFile });
       popToast("저장이 완료되었습니다.", "");
     } catch {
       popToast("저장에 실패했습니다.", "다시 시도해 주세요.");
@@ -44,7 +47,10 @@ const MyProfile = ({ profile }: { profile: Photographer }) => {
       >
         <div className={profileStyles.container}>
           <Preview />
-          <ProfileEdit />
+          <ProfileEdit
+            setBannerFile={setBannerFile}
+            setProfileFile={setProfileFile}
+          />
         </div>
         <SubmitProfile />
       </form>

--- a/src/containers/photographer/product/form/image-input.tsx
+++ b/src/containers/photographer/product/form/image-input.tsx
@@ -1,5 +1,4 @@
 import { Dispatch, SetStateAction, useRef, useState } from "react";
-import { Image } from "product-types";
 import { Modal } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import ImageThumbnail from "@/components/images/image-thumbnail";
@@ -8,13 +7,12 @@ import {
   FinishButton,
 } from "@/components/buttons/common-buttons";
 import { modalStyles } from "@/containers/customer/products/products.css";
-import { getUrlFromFiles } from "@/utils/image";
 import { formStyles } from "../product.css";
 // TODO: modal style 공통으로 옮기기
 
 interface ImageInputProps {
-  images: Image[];
-  setImage: Dispatch<SetStateAction<Image[]>>;
+  images: File[];
+  setImage: Dispatch<SetStateAction<File[]>>;
 }
 
 const ARRAY_START_INDEX = 0;
@@ -31,9 +29,7 @@ const ImagesInput = ({ images, setImage }: ImageInputProps) => {
     e.preventDefault();
     if (e.type === "drop") {
       const event = e as React.DragEvent;
-      const droppedImages = getUrlFromFiles(
-        Array.from(event.dataTransfer.files),
-      );
+      const droppedImages = Array.from(event.dataTransfer.files);
       setImage((prev) => {
         const newImages = [...prev, ...droppedImages].slice(
           ARRAY_START_INDEX,
@@ -43,9 +39,9 @@ const ImagesInput = ({ images, setImage }: ImageInputProps) => {
       });
     } else if (e.type === "change") {
       const inputElement = e.target as HTMLInputElement;
-      const selectedImages = getUrlFromFiles(
-        inputElement.files ? Array.from(inputElement.files) : [],
-      );
+      const selectedImages = inputElement.files
+        ? Array.from(inputElement.files)
+        : [];
       setImage((prev) => {
         const newImages = [...prev, ...selectedImages].slice(
           ARRAY_START_INDEX,
@@ -99,7 +95,7 @@ const ImagesInput = ({ images, setImage }: ImageInputProps) => {
           return (
             <ImageThumbnail
               key={index}
-              image={image}
+              image={URL.createObjectURL(image)}
               onClickDelete={() => handleDeleteImage(index)}
               size="20%"
               isRepresentative={index === 0}
@@ -112,6 +108,7 @@ const ImagesInput = ({ images, setImage }: ImageInputProps) => {
       </div>
       <CustomButton
         styleType="line"
+        disabled={images.length >= MAX_IMAGE_COUNT}
         size="md"
         style={{ marginTop: 20 }}
         onClick={() => InputRef.current?.click()}
@@ -121,7 +118,6 @@ const ImagesInput = ({ images, setImage }: ImageInputProps) => {
         type="file"
         accept="image/*"
         style={{ display: "none" }}
-        disabled={images.length >= MAX_IMAGE_COUNT}
         ref={InputRef}
         onChange={handleAddImage}
       />

--- a/src/containers/photographer/product/product-form.tsx
+++ b/src/containers/photographer/product/product-form.tsx
@@ -149,7 +149,7 @@ const ProductForm = () => {
     register,
     formState: { errors },
   } = method;
-  const [images, setImages] = useState<Image[]>([]);
+  const [images, setImages] = useState<File[]>([]);
 
   const onSubmit: SubmitHandler<ProductFormdata> = async (data) => {
     if (images.length === 0) {
@@ -162,7 +162,11 @@ const ProductForm = () => {
 
   return (
     <FormProvider {...method}>
-      <form className={formStyles.container} onSubmit={handleSubmit(onSubmit)}>
+      <form
+        className={formStyles.container}
+        onSubmit={handleSubmit(onSubmit)}
+        encType="multipart/form-data"
+      >
         <span className={formStyles.title}>촬영 정보 등록하기</span>
         <div className={formStyles.wrapper}>
           <div className={formStyles.split}>

--- a/src/containers/photographer/product/product.css.ts
+++ b/src/containers/photographer/product/product.css.ts
@@ -237,7 +237,7 @@ export const inputStyles = styleVariants({
       borderRadius: 8,
       padding: "8px 12px",
       ":focus": {
-        outline: "none",
+        borderColor: "#007AFF",
       },
     },
   ],

--- a/src/services/client/photographer/mypage/profile.ts
+++ b/src/services/client/photographer/mypage/profile.ts
@@ -1,7 +1,10 @@
 import { Photographer } from "profile-types";
 import apiClient from "../../core";
 
-export async function putProfile(form: Photographer) {
+export async function putProfile(
+  form: Photographer,
+  files: { bannerFile?: File; profileFile?: File },
+) {
   const formData = new FormData();
   const inputData = {
     instagramId: form.instagramId,
@@ -19,11 +22,11 @@ export async function putProfile(form: Photographer) {
   );
 
   // TODO: 업데이트된 request body 형식 확인 필요
-  if (form.bannerFile !== undefined) {
-    formData.append("bannerImage", form.bannerFile);
+  if (files.bannerFile !== undefined) {
+    formData.append("bannerImage", files.bannerFile);
   }
-  if (form.imgFile !== undefined) {
-    formData.append("profileImage", form.imgFile);
+  if (files.profileFile !== undefined) {
+    formData.append("profileImage", files.profileFile);
   }
 
   await apiClient.put("photographer/profile", {

--- a/src/services/client/photographer/mypage/profile.ts
+++ b/src/services/client/photographer/mypage/profile.ts
@@ -1,21 +1,32 @@
 import { Photographer } from "profile-types";
 import apiClient from "../../core";
 
-export async function putProfile(newProfile: Photographer) {
-  // TODO: 인스타그램 아이디 수정 여부 + 이미지 파일 형식 체크
-  const body = {
-    bannerImageUrl: newProfile.banner,
-    profileImageUrl: newProfile.profileImg,
-    instagramId: newProfile.instagramId,
-    introductionContent: newProfile.message,
-    linkInfos: newProfile.linkInfos.map((link) => {
+export async function putProfile(form: Photographer) {
+  const formData = new FormData();
+  const inputData = {
+    instagramId: form.instagramId,
+    introductionContent: form.message,
+    linkInfos: form.linkInfos.map((link) => {
       return {
         linkTitle: link.name,
         linkUrl: link.src,
       };
     }),
   };
+  formData.append(
+    "request",
+    new Blob([JSON.stringify(inputData)], { type: "application/json" }),
+  );
+
+  // TODO: 업데이트된 request body 형식 확인 필요
+  if (form.bannerFile !== undefined) {
+    formData.append("bannerImage", form.bannerFile);
+  }
+  if (form.imgFile !== undefined) {
+    formData.append("profileImage", form.imgFile);
+  }
+
   await apiClient.put("photographer/profile", {
-    body: JSON.stringify(body),
+    body: formData,
   });
 }

--- a/src/services/client/photographer/mypage/profile.ts
+++ b/src/services/client/photographer/mypage/profile.ts
@@ -21,7 +21,6 @@ export async function putProfile(
     new Blob([JSON.stringify(inputData)], { type: "application/json" }),
   );
 
-  // TODO: 업데이트된 request body 형식 확인 필요
   if (files.bannerFile !== undefined) {
     formData.append("bannerImage", files.bannerFile);
   }

--- a/src/services/client/photographer/products.ts
+++ b/src/services/client/photographer/products.ts
@@ -1,29 +1,26 @@
-import { Image, ProductFormdata } from "product-types";
+import { ProductFormdata } from "product-types";
 import apiClient from "../core";
 
-export async function postNewProduct(
-  formData: ProductFormdata,
-  images: Image[],
-) {
-  const body = {
-    productTitle: formData.title,
-    productDescription: formData.subtitle,
-    productImageUrls: images,
-    productComponents: formData.items.map((item) => {
+export async function postNewProduct(form: ProductFormdata, images: File[]) {
+  const formData = new FormData();
+  const inputData = {
+    productTitle: form.title,
+    productDescription: form.subtitle,
+    productComponents: form.items.map((item) => {
       return {
         title: item.title,
         content: item.content,
         description: item.description !== "" ? item.description : null,
       };
     }),
-    productOptions: formData.options.map((option) => {
+    productOptions: form.options.map((option) => {
       return {
         title: option.title,
         price: option.isFree ? 0 : option.price,
         description: option.description !== "" ? option.description : null,
       };
     }),
-    productDiscounts: formData.discounts.map((discount) => {
+    productDiscounts: form.discounts.map((discount) => {
       return {
         title: discount.title,
         discountType: discount.discountType,
@@ -32,9 +29,18 @@ export async function postNewProduct(
       };
     }),
   };
+  formData.append(
+    "request",
+    new Blob([JSON.stringify(inputData)], { type: "application/json" }),
+  );
+
+  images.forEach((image) => {
+    formData.append("images", image);
+  });
+
   const response = await apiClient
     .post("photographer/product", {
-      json: body,
+      body: formData,
     })
     .json();
   return response;

--- a/src/services/client/photographer/profile.ts
+++ b/src/services/client/photographer/profile.ts
@@ -1,7 +1,7 @@
 import { Join } from "profile-types";
 import apiClient from "../core";
 
-export async function postProfile(form: Join) {
+export async function postProfile(form: Join, profileImg?: File) {
   const formData = new FormData();
   const inputData = {
     instagramId: form.instagramId,
@@ -13,14 +13,13 @@ export async function postProfile(form: Join) {
     "request",
     new Blob([JSON.stringify(inputData)], { type: "application/json" }),
   );
-  if (form.profileImg) {
-    formData.append("image", form.profileImg);
+  if (profileImg !== undefined) {
+    formData.append("image", profileImg);
   }
 
   const { data } = await apiClient
     .post("photographer/join", {
       body: formData,
-      headers: { "content-type": "multipart/form-data" },
     })
     .json<{ data: string }>();
   return data;

--- a/src/types/profile-types.d.ts
+++ b/src/types/profile-types.d.ts
@@ -14,8 +14,6 @@ declare module "profile-types" {
   interface Photographer {
     banner?: string;
     profileImg?: string;
-    imgFile?: File;
-    bannerFile?: File;
     instagramId: string;
     message: string;
     linkInfos: LinkType[];

--- a/src/types/profile-types.d.ts
+++ b/src/types/profile-types.d.ts
@@ -22,7 +22,6 @@ declare module "profile-types" {
   }
 
   interface Join {
-    profileImg?: File;
     instagramId: string;
     serviceAgreement: boolean;
     privacyAgreement: boolean;


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 프로필 등록시 발생하는 multipart 요청 관련 에러 픽스
* 이미지 등록을 포함하지만 기존에 multipart로 요청되지 않았던 요청 수정


### 1. 현상 파악
- 이미지 파일을 포함하는 multipart/form-data 형식의 요청에서 500 "Failed to parse multipart servlet request" 에러 발생

### 2. 분석하기
- a. 사진을 등록했을 때 react-hook-form의 필드 업데이트가 제대로 이루어지지 않고, submit 시점에 프로필 사진 필드가 undefined로 전달되고 있음을 파악
- b. 요청에 대해 명시적으로 "content-type": "multipart/form-data" 헤더를 지정할 경우, 브라우저에서 설정한 바운더리를 덮어씌워 잘못된 바운더리를 세팅하면서 문제가 생긴다는 점을 파악

### 3. 조치하기
- a. `<input>`과 react-hook-form을 재차 연결하고자 시도했으나 submit 시점에 file field가 undefined인 문제는 해결되지 않음. 또한 복수의 파일을 입력해야 하는 경우 useArrayField를 사용하면서 프리뷰를 위한 url을 따로 관리하는 방식으로 수정하는 데 개발 비용이 많이 들 것으로 여겨져 우선 파일 입력은 별도의 상태로 분리해 관리하는 방향으로 조치함.
- b. 요청 헤더에 명시적으로 "content-type": "multipart/form-data"를 지정하지 않고, form의 encType은 추가하였음.

### 4. 검증하기
- a. 로컬 환경에서 요청 보낼 시 content-type이 제대로 설정되고 있고, body로 이미지 파일을 포함한 formData가 전달되어 정상적으로 등록되는 것을 확인함. 머지 이후 배포 환경에서 테스트 진행 예정.
- b. 이후 추가로 이미지 파일 이름이 너무 길어 DB 저장이 불가능한 에러에 대해 핸들링이 요구되었음. 단 에러 핸들링에 대해 고민해 보았을 때 공통 에러 핸들링 로직에서 처리해 줘야 할 부분이 생길 것으로 예상되어 포함하지 않았음.

## 리뷰 요청사항
* 프로필 수정 api에서도 이미지를 전송하게 될 수 있어 마찬가지로 수정 범위에 포함하였는데, api docs 기준으로는 아직 multipart로 기록되어 있지 않아서 한 번 확인 부탁드립니다 🙇
