### PR TITLE
[FU-258] 배포 자동화 스크립트 버그 픽스

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -17,9 +17,6 @@ jobs:
       - name: Check Node v
         run: node -v
 
-      - name: Install Dependencies
-        run: npm install
-
       - name: env 설정
         run: |
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
@@ -32,9 +29,6 @@ jobs:
           echo "NEXT_PUBLIC_KAKAO_DOMAIN=${{ secrets.NEXT_PUBLIC_KAKAO_DOMAIN }}" >> .env
           echo "NEXT_PUBLIC_AUTH_KAKAO_KEY=${{ secrets.NEXT_PUBLIC_AUTH_KAKAO_KEY }}" >> .env
           echo "NEXT_PUBLIC_DOMAIN=${{ secrets.NEXT_PUBLIC_DOMAIN }}" >> .env
-
-      - name: Build
-        run: npm run build
 
       - name: 압축
         run: zip -r ./frontend_freebe.zip .

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Check Node v
         run: node -v
 
+      - name: npm 설치
+        run: npm install
+
       - name: env 설정
         run: |
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
@@ -29,6 +32,9 @@ jobs:
           echo "NEXT_PUBLIC_KAKAO_DOMAIN=${{ secrets.NEXT_PUBLIC_KAKAO_DOMAIN }}" >> .env
           echo "NEXT_PUBLIC_AUTH_KAKAO_KEY=${{ secrets.NEXT_PUBLIC_AUTH_KAKAO_KEY }}" >> .env
           echo "NEXT_PUBLIC_DOMAIN=${{ secrets.NEXT_PUBLIC_DOMAIN }}" >> .env
+
+      - name: 프로젝트 빌드
+        run: npm run build
 
       - name: 압축
         run: zip -r ./frontend_freebe.zip .

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -3,6 +3,8 @@ name: Frontend Dev Server CD
 on:
   push:
     branches: ["develop"]
+  pull_request:
+    branches: ["develop"]
 
 jobs:
   build:

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -16,10 +16,7 @@ jobs:
 
       - name: Check Node v
         run: node -v
-
-      - name: npm 설치
-        run: npm install
-
+        
       - name: env 설정
         run: |
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
@@ -32,9 +29,6 @@ jobs:
           echo "NEXT_PUBLIC_KAKAO_DOMAIN=${{ secrets.NEXT_PUBLIC_KAKAO_DOMAIN }}" >> .env
           echo "NEXT_PUBLIC_AUTH_KAKAO_KEY=${{ secrets.NEXT_PUBLIC_AUTH_KAKAO_KEY }}" >> .env
           echo "NEXT_PUBLIC_DOMAIN=${{ secrets.NEXT_PUBLIC_DOMAIN }}" >> .env
-
-      - name: 프로젝트 빌드
-        run: npm run build
 
       - name: 압축
         run: zip -r ./frontend_freebe.zip .

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -3,9 +3,7 @@ name: Frontend Dev Server CD
 on:
   push:
     branches: ["develop"]
-  pull_request:
-    branches: ["develop"]
-
+  
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/appspec.yml
+++ b/appspec.yml
@@ -5,7 +5,7 @@ files:
   - source: /
     destination: /home/ubuntu/freebe-frontend
     overwrite: yes
-file_exists_behavior: OVERWRITE
+#file_exists_behavior: OVERWRITE
 
 permissions:
   - object: /

--- a/appspec.yml
+++ b/appspec.yml
@@ -21,6 +21,6 @@ hooks:
       
   ApplicationStart:
     - location: scripts/start.sh
-      timeout: 60
+      timeout: 600
       runas : root
       

--- a/appspec.yml
+++ b/appspec.yml
@@ -17,10 +17,10 @@ hooks:
   ApplicationStop:
     - location: scripts/stop.sh
       timeout: 60
-      runas : ubuntu
+      runas : root
       
   ApplicationStart:
     - location: scripts/start.sh
       timeout: 600
-      runas : ubuntu
-      
+      runas : root
+      # check

--- a/appspec.yml
+++ b/appspec.yml
@@ -21,6 +21,6 @@ hooks:
       
   ApplicationStart:
     - location: scripts/start.sh
-      timeout: 600
+      timeout: 60
       runas : root
-      # check
+    

--- a/appspec.yml
+++ b/appspec.yml
@@ -17,10 +17,10 @@ hooks:
   ApplicationStop:
     - location: scripts/stop.sh
       timeout: 60
-      runas : root
+      runas : ubuntu
       
   ApplicationStart:
     - location: scripts/start.sh
       timeout: 600
-      runas : root
+      runas : ubuntu
       

--- a/appspec.yml
+++ b/appspec.yml
@@ -5,7 +5,7 @@ files:
   - source: /
     destination: /home/ubuntu/freebe-frontend
     overwrite: yes
-#file_exists_behavior: OVERWRITE
+file_exists_behavior: OVERWRITE
 
 permissions:
   - object: /

--- a/appspec.yml
+++ b/appspec.yml
@@ -21,6 +21,6 @@ hooks:
       
   ApplicationStart:
     - location: scripts/start.sh
-      timeout: 60
+      timeout: 600
       runas : root
     

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,6 +13,7 @@ LOG_FILE="$ROOT_PATH/start.log"
 cd $ROOT_PATH
 
 npm install
+npm run build
 
 # 로그 기록 시작
 {

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -22,7 +22,7 @@ npm run build
     
     # 애플리케이션 실행
     echo "Starting PM2 process..."
-    sudo pm2 start ecosystem_3000.config.js
+    pm2 start ecosystem_3000.config.js
 
     echo "Deployment completed."
 } >> "$LOG_FILE" 2>&1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,22 +7,23 @@ set +o allexport
 
 # 경로 및 파일 설정
 ROOT_PATH="/home/ubuntu/freebe-frontend"
-
 LOG_FILE="$ROOT_PATH/start.log"
+NOW=$(date "+%Y %b %d %a %H:%M:%S")
+
+echo "--------------------------------------------------" | tee -a $LOG_FILE
 
 cd $ROOT_PATH
 
+echo "[$NOW] npm install start" | tee -a $LOG_FILE
 npm install
+
+echo "[$NOW] npm run build start" | tee -a $LOG_FILE
 npm run build
 
 # 로그 기록 시작
 {
-    echo "Starting deployment..."
-    echo "Loading environment variables..."
-    
-    # 애플리케이션 실행
-    echo "Starting PM2 process..."
+    echo "[$NOW] start pm2 process"
     pm2 start ecosystem_3000.config.js
 
-    echo "Deployment completed."
+    echo "[$NOW] Deployment completed."
 } >> "$LOG_FILE" 2>&1

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -14,4 +14,6 @@ if pm2 describe "$APP_NAME" > /dev/null; then
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
 else
     echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
+    exit 0
 fi
+

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -8,16 +8,15 @@ LOG_FILE="/home/ubuntu/freebe-frontend/delete.log"
 
 cd /home/ubuntu/freebe-frontend
 
-echo "--------------------------------------------------" >> $LOG_FILE
+echo "--------------------------------------------------" >> | tee -a $LOG_FILE
 
 SERVICE_PID=$(pm2 pid $APP_NAME)
 # 현재 PM2 프로세스를 찾고 삭제
 if [ -z "$SERVICE_PID" ]; then
     echo "[$NOW] No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
 else
-    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 시도" >> $LOG_FILE
+    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 시도" >> | tee -a $LOG_FILE
     echo "[$NOW] Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
-    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 성공" >> $LOG_FILE
+    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 성공" >> | tee -a $LOG_FILE
 fi
-

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -8,8 +8,11 @@ LOG_FILE="delete.log"
 
 cd /home/ubuntu/freebe-fronted
 
+echo "--------------------------------------------------" >> $LOG_FILE
+
+SERVICE_PID=$(pm2 pid $APP_NAME)
 # 현재 PM2 프로세스를 찾고 삭제
-if pm2 pid "$APP_NAME"; then
+if [-z "$SERVICE_PID" ]; then
     echo "[$NOW] Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
 else

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# PM2 프로세스 이름 (또는 ID)
-APP_NAME="freebe3000"
+# # PM2 프로세스 이름 (또는 ID)
+# APP_NAME="freebe3000"
 
-# 로그 파일 경로
-LOG_FILE="delete.log"
+# # 로그 파일 경로
+# LOG_FILE="delete.log"
 
-cd /home/ubuntu/freebe-fronted
+# cd /home/ubuntu/freebe-fronted
 
-# 현재 PM2 프로세스를 찾고 삭제
-if pm2 pid "$APP_NAME"; then
-    echo "Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
-    pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
-else
-    echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
-fi
+# # 현재 PM2 프로세스를 찾고 삭제
+# if pm2 pid "$APP_NAME"; then
+#     echo "Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
+#     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
+# else
+#     echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
+# fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -2,7 +2,7 @@
 
 # PM2 프로세스 이름 (또는 ID)
 APP_NAME="freebe3000"
-
+NOW=$(date "+%Y %b %d %a %H:%M:%S")
 # 로그 파일 경로
 LOG_FILE="delete.log"
 
@@ -10,9 +10,9 @@ cd /home/ubuntu/freebe-fronted
 
 # 현재 PM2 프로세스를 찾고 삭제
 if pm2 pid "$APP_NAME"; then
-    echo "Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
+    echo "[$NOW] Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
 else
-    echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
+    echo "[$NOW] No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
 fi
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -9,9 +9,9 @@ LOG_FILE="delete.log"
 cd /home/ubuntu/freebe-frontend
 
 # 현재 PM2 프로세스를 찾고 삭제
-if sudo pm2 pid "$APP_NAME"; then
+if pm2 pid "$APP_NAME"; then
     echo "Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
-    sudo pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
+    pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
 else
     echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
 fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -8,15 +8,15 @@ LOG_FILE="/home/ubuntu/freebe-frontend/delete.log"
 
 cd /home/ubuntu/freebe-frontend
 
-echo "--------------------------------------------------" >> | tee -a $LOG_FILE
+echo "--------------------------------------------------" | tee -a $LOG_FILE
 
 SERVICE_PID=$(pm2 pid $APP_NAME)
 # 현재 PM2 프로세스를 찾고 삭제
 if [ -z "$SERVICE_PID" ]; then
     echo "[$NOW] No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
 else
-    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 시도" >> | tee -a $LOG_FILE
+    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 시도" | tee -a $LOG_FILE
     echo "[$NOW] Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
-    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 성공" >> | tee -a $LOG_FILE
+    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 성공" | tee -a $LOG_FILE
 fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -13,11 +13,11 @@ echo "--------------------------------------------------" >> $LOG_FILE
 SERVICE_PID=$(pm2 pid $APP_NAME)
 # 현재 PM2 프로세스를 찾고 삭제
 if [ -z "$SERVICE_PID" ]; then
+    echo "[$NOW] No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
+else
     echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 시도" >> $LOG_FILE
     echo "[$NOW] Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
     echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 성공" >> $LOG_FILE
-else
-    echo "[$NOW] No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
 fi
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-# # PM2 프로세스 이름 (또는 ID)
-# APP_NAME="freebe3000"
+# PM2 프로세스 이름 (또는 ID)
+APP_NAME="freebe3000"
 
-# # 로그 파일 경로
-# LOG_FILE="delete.log"
+# 로그 파일 경로
+LOG_FILE="delete.log"
 
-# cd /home/ubuntu/freebe-fronted
+cd /home/ubuntu/freebe-fronted
 
-# # 현재 PM2 프로세스를 찾고 삭제
-# if pm2 pid "$APP_NAME"; then
-#     echo "Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
-#     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
-# else
-#     echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
-# fi
-exit 0
+# 현재 PM2 프로세스를 찾고 삭제
+if pm2 pid "$APP_NAME"; then
+    echo "Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
+    pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
+else
+    echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
+fi
+

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -4,7 +4,7 @@
 APP_NAME="freebe3000"
 NOW=$(date "+%Y %b %d %a %H:%M:%S")
 # 로그 파일 경로
-LOG_FILE="delete.log"
+LOG_FILE="/home/ubuntu/freebe-frontend/delete.log"
 
 cd /home/ubuntu/freebe-frontend
 
@@ -12,7 +12,7 @@ echo "--------------------------------------------------" >> $LOG_FILE
 
 SERVICE_PID=$(pm2 pid $APP_NAME)
 # 현재 PM2 프로세스를 찾고 삭제
-if [-z "$SERVICE_PID" ]; then
+if [ -z "$SERVICE_PID" ]; then
     echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 시도" >> $LOG_FILE
     echo "[$NOW] Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -6,7 +6,7 @@ APP_NAME="freebe3000"
 # 로그 파일 경로
 LOG_FILE="delete.log"
 
-cd /home/ubuntu/freebe-fronted
+cd /home/ubuntu/freebe-frontend
 
 # 현재 PM2 프로세스를 찾고 삭제
 if sudo pm2 pid "$APP_NAME"; then

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -6,7 +6,7 @@ NOW=$(date "+%Y %b %d %a %H:%M:%S")
 # 로그 파일 경로
 LOG_FILE="delete.log"
 
-cd /home/ubuntu/freebe-fronted
+cd /home/ubuntu/freebe-frontend
 
 echo "--------------------------------------------------" >> $LOG_FILE
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -15,3 +15,4 @@
 # else
 #     echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
 # fi
+exit 0

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -13,8 +13,10 @@ echo "--------------------------------------------------" >> $LOG_FILE
 SERVICE_PID=$(pm2 pid $APP_NAME)
 # 현재 PM2 프로세스를 찾고 삭제
 if [-z "$SERVICE_PID" ]; then
+    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 시도" >> $LOG_FILE
     echo "[$NOW] Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
+    echo "[$NOW] 기존에 존재하는 pm2 프로세스 중단 성공" >> $LOG_FILE
 else
     echo "[$NOW] No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
 fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -9,7 +9,7 @@ LOG_FILE="delete.log"
 cd /home/ubuntu/freebe-frontend
 
 # 현재 PM2 프로세스를 찾고 삭제
-if pm2 pid "$APP_NAME"; then
+if pm2 describe "$APP_NAME" > /dev/null; then
     echo "Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
 else

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -6,14 +6,12 @@ APP_NAME="freebe3000"
 # 로그 파일 경로
 LOG_FILE="delete.log"
 
-cd /home/ubuntu/freebe-frontend
+cd /home/ubuntu/freebe-fronted
 
 # 현재 PM2 프로세스를 찾고 삭제
-if pm2 describe "$APP_NAME" > /dev/null; then
+if pm2 pid "$APP_NAME"; then
     echo "Stopping existing PM2 process for $APP_NAME..." | tee -a $LOG_FILE
     pm2 delete "$APP_NAME" >> $LOG_FILE 2>&1
 else
     echo "No existing PM2 process found for $APP_NAME." | tee -a $LOG_FILE
-    exit 0
 fi
-


### PR DESCRIPTION
## 체크리스트

-  ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
* 기존의 CodeDeploy를 이용한 배포 작업이 정상적으로 이뤄지지 않는 것에 대해 AWS 환경 세팅과 스크립트를 수정하였습니다.


### 1. 현상 파악
- PR에 해당하는 브랜치의 코드를 zip파일로 압축하여 S3에 업로드는 정상적으로 이뤄졌지만, 이후 `appspec.yml` 스크립트를 통해 CodeDeploy가 구동하는 과정에서 설정한 hooks의 `stop.sh(ApplicationStop)`에서 지속적으로 비정상 종료가 되었습니다.

### 2. 분석하기
- a. 스크립트에 대한 오류로 인해 비정상 종료가 되는 경우
- b. CodeDeploy의 배포그룹이 비정상적으로 현재 새로 업데이트 된 zip파일 가져오지 못하여 이전 코드로 appspec.yml 스크립트를 수행하지 못하는 경우
- c. EC2 인스턴스와 CodeDeploy의 타겟팅이 잘못된 경우 (CodeDeploy의 구조는 비교적 간단하기 때문에 EC2 서버의 문제일 가능성이 높습니다.)

### 3. 조치하기
- a. 모든 스크립트 내에 sudo 명령어 삭제 + 스크립트 단계마다 로그를 작성하여 서버와 CodeDeploy-Agent의 로그에서 진행정도 체크 (도와준 유리 너무 고마워🙇‍♂️)
- b. code deploy 배포 그룹 재 생성 후 배포할 EC2 인스턴스에 타겟
- c. EC2 인스턴스 재부팅

### 4. 검증하기
- a. start.log와 codedeploy-agent.log를 통해 정상적으로 로그가 작성되는지 확인하였습니다.
- b. 타겟한 EC2에 정상적으로 appspec.yml 스크립트를 수행하였습니다. (AWS CodeDeploy 배포의 이벤트에서 확인 가능합니다!)
- c. 인스턴스에서 로그 확인 및 서버 배포가 정상적으로 작동하는지 확인하였습니다.
- 위와 같은 방식으로 Front_SecondServer 인스턴스에서 5번의 테스트 통과 후 메인서버인 Frontend_BasicServer로 CodeDeploy 배포그룹의 타겟을 변경하여 총 9번의 테스트 통과를 하였습니다.

## 리뷰 요청사항
- 현재 배포할 때 모두 sudo를 제외하고 스크립트를 수행하지만 pm2 status로는 서버 체킹이 되지 않고 sudo pm2 status로 체킹된다는 점이 어색하지만 sudo는 단순 권한에 대한 차이이기 때문에 파악하지 못한 권한 문제가 있을 수 있습니다. 하지만 여러 번의 테스트 통과와 권한 문제가 현 시점에서는 중요도가 높지 않고 출시를 위해 이어나가야 할 테스크가 있기 때문에 여기서 마무리하려고 합니다.
- 이번 에러픽스 PR을 병합한 후 다음 PR을 병합했을 때 문제없이 배포 된다면 90% 성공일 것 같네요..ㅎㅎ
