### PR TITLE
[FU-259] set request content type

### DIFF
--- a/src/app/(customer)/[profileName]/main.css.ts
+++ b/src/app/(customer)/[profileName]/main.css.ts
@@ -15,7 +15,7 @@ export const layoutStyle = style({
 export const mainStyle = style({
   display: "flex",
   flexDirection: "column",
-  height: "100%",
+  height: "100vh",
   width: "100%",
   overflowY: "hidden",
   overflowX: "hidden",

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -10,7 +10,7 @@ const LoginLayout = ({
   return (
     <div>
       <div className={loginPageStyles.layout}>
-        <Header />
+        <Header isOnboarding />
         {children}
       </div>
       <ServiceFooter />

--- a/src/containers/photographer/main/header.tsx
+++ b/src/containers/photographer/main/header.tsx
@@ -13,7 +13,7 @@ const Header = () => {
   useEffect(() => {
     const localData = localStorage.getItem("url");
     if (localData) {
-      setUrl(`${process.env.NEXT_PUBLIC_DOMAIN}/${localData}`);
+      setUrl(`${process.env.NEXT_PUBLIC_DOMAIN}${localData}`);
     }
   });
 

--- a/src/containers/photographer/main/header.tsx
+++ b/src/containers/photographer/main/header.tsx
@@ -7,7 +7,7 @@ import * as styles from "./header/header.css";
 import Profile from "./header/profile";
 import Url from "./header/url";
 
-const Header = () => {
+const Header = ({ isOnboarding }: { isOnboarding?: boolean }) => {
   const [url, setUrl] = useState<string | null>();
 
   useEffect(() => {
@@ -27,7 +27,7 @@ const Header = () => {
           alt="free:be"
         />
       </Link>
-      {url && (
+      {url && !isOnboarding && (
         <>
           <Url myUrl={url} />
           <Profile />

--- a/src/services/client/core/interceptor.ts
+++ b/src/services/client/core/interceptor.ts
@@ -10,6 +10,9 @@ export const beforeRequest: BeforeRequestHook = async (request) => {
     const data = await response.json();
     setAuthorizationHeader(request, data.accessToken);
   }
+  if (!request.headers.has("Content-Type")) {
+    request.headers.set("Content-Type", "application/json");
+  }
 };
 
 export const beforeRetry: BeforeRetryHook = async ({ error }) => {

--- a/src/services/client/customer/reservation.ts
+++ b/src/services/client/customer/reservation.ts
@@ -60,7 +60,7 @@ export async function cancelReservation(
     cancellationReason,
   };
   const response = await apiClient.put(`customer/reservation/${id}`, {
-    body: JSON.stringify(body),
+    json: body,
   });
   if (!response.ok) {
     throw new Error();

--- a/src/services/client/photographer/profile.ts
+++ b/src/services/client/photographer/profile.ts
@@ -10,7 +10,7 @@ export async function postProfile(form: Join) {
   };
   const { data } = await apiClient
     .post("photographer/join", {
-      body: JSON.stringify(body),
+      json: body,
     })
     .json<{ data: string }>();
   return data;

--- a/src/services/client/photographer/reservations.ts
+++ b/src/services/client/photographer/reservations.ts
@@ -37,7 +37,7 @@ export async function putReservationStatus(
   const response = await apiClient.put(
     `photographer/reservation/details/${id}`,
     {
-      body: JSON.stringify(body),
+      json: body,
     },
   );
 }

--- a/src/services/server/core/interceptor.ts
+++ b/src/services/server/core/interceptor.ts
@@ -8,6 +8,9 @@ import { getAccessToken, reissueTokens } from "./auth";
 export const beforeRequest: BeforeRequestHook = (request) => {
   const accessToken = getAccessToken();
   setAuthorizationHeader(request, accessToken);
+  if (!request.headers.has("Content-Type")) {
+    request.headers.set("Content-Type", "application/json");
+  }
 };
 
 export const beforeRetry: BeforeRetryHook = async ({ error }) => {


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* api 요청시 기본 요청 타입 application/json으로 세팅
* 세팅 이후 온보딩 과정에서 발생하는 UI 관련 버그 픽스

1. 현상 파악
photographer/join api 요청시 415 Unsupported Media Type 에러 발생

2. 분석하기
a. 로컬에서 요청시 정상적으로 "content-type": "application/json" 헤더가 포함되는 것과 달리 배포 환경에서 요청시 "content-type": "text/plain"이 포함되고 있음을 파악
b. 환경에 따라 디폴트 헤더 구성에 차이가 발생해서 생기는 문제일 수 있음을 확인

3. 조치하기
a. interceptor 단계에서 header를 고정하는 것은 다른 content type을 사용하는 요청에 문제를 발생시킬 수 있을 것으로 보여, 헤더가 세팅되지 않았다면 디폴트로 application/json을 설정하도록 함.
b. api 요청 레벨에서 `body` 옵션 대신 `json` 옵션을 사용 ([Shortcut for sending JSON. Use this instead of the body option. Accepts any plain object or value, which will be JSON.stringify()'d and sent in the body with the correct header set.](https://github.com/sindresorhus/ky?tab=readme-ov-file#json))

4. 검증하기
a. 조치 (a)까지 진행했을 때는 배포 환경에서 발생하는 오류가 해결되지 않았음.
b. 조치 (b)를 통해 동일 요청(`photographer/join`)에 대해 오류 해결되는 것 확인. 다른 content-type을(multipart/form-data) 사용 중인 api 요청(상품 등록)에서 헤더 정상적으로 세팅되는 것 확인.
b-2. 온보딩(로그인 - 사진작가 가입) 과정 및 사진작가측 api(상품 등록, 상품 상태 변경, 프로필 설정), 의뢰자측 api(프로필 조회, 상품 목록 조회, 상품 상세 조회) 일부 배포 환경에서 테스트 진행하였으며, 간단한 UI 문제를 수정함.

5. 회고
a. 로컬 환경에서 정상 동작하는 것만 확인하고 명시적으로 content-type 헤더를 세팅하지 않았는데 배포 환경과의 차이가 문제를 발생시킬 수 있다는 점을 확인했습니다 🥲 환경과 무관하게 안전히 동작할 수 있도록 코드 레벨에서 더 엄밀히 작성하는 게 좋겠다는 생각을 했고, 앞으로는 배포 환경에서도 꼼꼼히 테스트해 보겠습니다 👍


## 리뷰 요청사항
* 시급도: `보통`
배포 환경에서 정상적으로 테스트 진행하기 위해 필요합니다! 다만 해당 브랜치에서 임시로 배포해 둬서 당장 문제가 되지는 않을 것 같습니다.
