### PR TITLE
[FU-262] redirect by middleware

### DIFF
--- a/src/app/login/error/page.tsx
+++ b/src/app/login/error/page.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { handlerStyles } from "@/app/root.css";
-import { FinishButton } from "@/components/buttons/common-buttons";
+import { CustomButton } from "@/components/buttons/common-buttons";
 import Link from "next/link";
 
 const LoginErrorPage = () => {
   return (
     <div className={handlerStyles.fullContainer}>
-      <span>로그인에 실패했습니다.</span>
+      <span className={handlerStyles.message}>로그인에 실패했습니다.</span>
       <Link href="/login">
-        <FinishButton onClick={() => {}} title="메인으로 돌아가기" />
+        <CustomButton title="메인으로 돌아가기" styleType="primary" size="sm" />
       </Link>
     </div>
   );

--- a/src/app/login/page.css.ts
+++ b/src/app/login/page.css.ts
@@ -3,10 +3,10 @@ import { styleVariants } from "@vanilla-extract/css";
 
 export const loginPageStyles = styleVariants({
   background: [
+    sprinkles({ backgroundColor: "bg-lightgrey" }),
     {
       padding: "101px 0px 50px 0px",
       position: "relative",
-      width: "100vw",
       minWidth: 350,
 
       display: "flex",
@@ -17,7 +17,6 @@ export const loginPageStyles = styleVariants({
     },
   ],
   layout: [
-    sprinkles({ backgroundColor: "bg-lightgrey" }),
     {
       width: "100vw",
       minHeight: "100vh",

--- a/src/app/login/redirect/route.ts
+++ b/src/app/login/redirect/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { isUser } from "@/utils/type-guards";
 import { login } from "@/services/server/login";
-import { setTokens } from "@/services/server/core/auth";
+import { setTokens, setUserRole } from "@/services/server/core/auth";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -28,15 +28,18 @@ export async function GET(request: NextRequest) {
 
   function getRedirectDestination(responseMessage: string): string {
     if (responseMessage === "photographer join") {
+      setUserRole("photographer");
       return "photographer/join";
     }
     if (responseMessage === "photographer login") {
+      setUserRole("photographer");
       return `photographer?url=${data}`;
     }
     if (
       responseMessage === "customer login" ||
       responseMessage === "customer join"
     ) {
+      setUserRole("customer");
       return destination as string;
     }
     return "login/error";

--- a/src/components/buttons/buttons.css.ts
+++ b/src/components/buttons/buttons.css.ts
@@ -51,7 +51,7 @@ const buttonStyles = styleVariants({
     alignItems: "center",
     justifyContent: "flex-start",
     padding: 20,
-    margin: 30,
+    marginTop: 30,
     gap: 42,
     border: 0,
     width: 280,

--- a/src/components/buttons/login-button.tsx
+++ b/src/components/buttons/login-button.tsx
@@ -1,25 +1,28 @@
 "use client";
 
 import Image from "next/image";
-import { User } from "user-types";
 import buttonStyles from "./buttons.css";
 
 const LoginButton = ({
-  roleType,
-  product,
-  id,
+  type,
 }: {
-  roleType: User;
-  product?: string;
-  id?: string;
+  type:
+    | {
+        roleType: "customer";
+        destination: string;
+      }
+    | {
+        roleType: "photographer";
+      };
 }) => {
+  const { roleType } = type;
   const redirectUri = `${process.env.NEXT_PUBLIC_DOMAIN}login/redirect`;
   const stateValue =
     roleType === "photographer"
       ? { roleType }
       : {
           roleType,
-          destination: `${process.env.NEXT_PUBLIC_DOMAIN}${id}/products/${product}/reservation/reference`,
+          destination: `${process.env.NEXT_PUBLIC_DOMAIN}${type.destination}`,
         };
 
   function loginToKakao() {

--- a/src/components/buttons/login-button.tsx
+++ b/src/components/buttons/login-button.tsx
@@ -1,29 +1,21 @@
 "use client";
 
 import Image from "next/image";
+import { User } from "user-types";
 import buttonStyles from "./buttons.css";
 
 const LoginButton = ({
-  type,
+  roleType,
+  destination,
 }: {
-  type:
-    | {
-        roleType: "customer";
-        destination: string;
-      }
-    | {
-        roleType: "photographer";
-      };
+  roleType: User;
+  destination: string;
 }) => {
-  const { roleType } = type;
   const redirectUri = `${process.env.NEXT_PUBLIC_DOMAIN}login/redirect`;
-  const stateValue =
-    roleType === "photographer"
-      ? { roleType }
-      : {
-          roleType,
-          destination: `${process.env.NEXT_PUBLIC_DOMAIN}${type.destination}`,
-        };
+  const stateValue = {
+    roleType,
+    destination: `${process.env.NEXT_PUBLIC_DOMAIN}${destination}`,
+  };
 
   function loginToKakao() {
     window.location.href = `${process.env.NEXT_PUBLIC_KAKAO_DOMAIN}oauth/authorize?response_type=code&client_id=${process.env.NEXT_PUBLIC_AUTH_KAKAO_KEY}&redirect_uri=${redirectUri}&state=${JSON.stringify(stateValue)}`;

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,4 +1,5 @@
 export const tokenKeys = {
   access: "accessToken",
   refresh: "refreshToken",
+  user: "role",
 };

--- a/src/containers/common/image-stack/image-stack.css.ts
+++ b/src/containers/common/image-stack/image-stack.css.ts
@@ -42,8 +42,10 @@ export const imageStackStyles = styleVariants({
   container: [
     {
       alignSelf: "center",
-      margin: "80px 0",
-      width: "100%",
+      marginTop: 30,
+      marginBottom: 80,
+      minWidth: 600,
+      flex: "1 0 60%",
       display: "flex",
       flexDirection: "row",
       alignItems: "center",
@@ -53,7 +55,12 @@ export const imageStackStyles = styleVariants({
       backgroundRepeat: "no-repeat",
       backgroundPosition: "center",
       "@media": {
+        "screen and (max-height: 900px)": {
+          minWidth: 300,
+        },
         [breakpoints.mobile]: {
+          minWidth: 300,
+          width: "100%",
           margin: "40px 0",
         },
       },

--- a/src/containers/customer/login/index.tsx
+++ b/src/containers/customer/login/index.tsx
@@ -2,10 +2,11 @@
 
 import ImageStack from "@/containers/common/image-stack/image-stack";
 import LoginInfo from "./info";
+import { loginStyles } from "./login.css";
 
 const Login = ({ images }: { images: string[] }) => {
   return (
-    <div style={{ width: "100%", maxWidth: 1000, minHeight: "auto" }}>
+    <div className={loginStyles.layout}>
       <ImageStack images={images} />
       <LoginInfo />
     </div>

--- a/src/containers/customer/login/info.tsx
+++ b/src/containers/customer/login/info.tsx
@@ -31,7 +31,7 @@ const LoginInfo = () => {
         프리비와 함께 예약부터 촬영까지 시작해보세요
       </span>
       {!isLoading && (
-        <LoginButton type={{ roleType: "customer", destination }} />
+        <LoginButton roleType="customer" destination={destination} />
       )}
       <Link href="/login/photographer" className={loginStyles.caption}>
         <span>작가로 로그인하기</span>

--- a/src/containers/customer/login/info.tsx
+++ b/src/containers/customer/login/info.tsx
@@ -1,8 +1,27 @@
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import LoginButton from "@/components/buttons/login-button";
 import { loginStyles } from "./login.css";
 
 const LoginInfo = () => {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [destination, setDestination] = useState("customer");
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const redirect = searchParams.get("redirect");
+    if (redirect) {
+      const decodedUrl = decodeURIComponent(redirect);
+      setDestination(
+        decodedUrl.startsWith("/") ? decodedUrl.slice(1) : decodedUrl,
+      );
+      router.replace("/login/customer");
+    }
+    setIsLoading(false);
+  }, [searchParams, router]);
+
   return (
     <div className={loginStyles.container}>
       <span className={loginStyles.title}>
@@ -11,7 +30,9 @@ const LoginInfo = () => {
       <span className={loginStyles.subtitle}>
         프리비와 함께 예약부터 촬영까지 시작해보세요
       </span>
-      <LoginButton roleType="customer" />
+      {!isLoading && (
+        <LoginButton type={{ roleType: "customer", destination }} />
+      )}
       <Link href="/login/photographer" className={loginStyles.caption}>
         <span>작가로 로그인하기</span>
       </Link>

--- a/src/containers/customer/login/info.tsx
+++ b/src/containers/customer/login/info.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import LoginButton from "@/components/buttons/login-button";
 import { loginStyles } from "./login.css";
 
@@ -11,6 +12,9 @@ const LoginInfo = () => {
         프리비와 함께 예약부터 촬영까지 시작해보세요
       </span>
       <LoginButton roleType="customer" />
+      <Link href="/login/photographer" className={loginStyles.caption}>
+        <span>작가로 로그인하기</span>
+      </Link>
     </div>
   );
 };

--- a/src/containers/customer/login/login.css.ts
+++ b/src/containers/customer/login/login.css.ts
@@ -1,13 +1,31 @@
+import { breakpoints } from "@/styles/breakpoints.css";
 import sprinkles from "@/styles/sprinkles.css";
 import { texts } from "@/styles/text.css";
 import { styleVariants } from "@vanilla-extract/css";
 
 export const loginStyles = styleVariants({
+  layout: {
+    display: "flex",
+    flexWrap: "wrap",
+    width: "100%",
+    minHeight: "auto",
+    padding: "0px 100px",
+    columnGap: 50,
+
+    "@media": {
+      [breakpoints.mobile]: {
+        padding: 0,
+      },
+    },
+  },
   container: {
+    margin: "auto",
+    flexGrow: 0.7,
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    minWidth: "auto",
+    alignSelf: "center",
+    minWidth: "fit-content",
   },
   title: [
     texts["headline-02"],
@@ -20,5 +38,12 @@ export const loginStyles = styleVariants({
     sprinkles({
       color: "text-01",
     }),
+  ],
+  caption: [
+    texts["headline-03"],
+    sprinkles({
+      color: "text-03",
+    }),
+    { textDecoration: "underline", marginTop: 10 },
   ],
 });

--- a/src/containers/customer/products/info.tsx
+++ b/src/containers/customer/products/info.tsx
@@ -39,7 +39,12 @@ const ProductInfo = ({
         <span className={modalStyles.info}>
           작가님께 신청자 정보를 간편하게 전달하기 위해 로그인을 해 주세요!
         </span>
-        <LoginButton roleType="customer" id={profileName} product={productId} />
+        <LoginButton
+          type={{
+            roleType: "customer",
+            destination: `${profileName}/products/${productId}/reservation/reference`,
+          }}
+        />
       </Modal>
       <Carousel
         withIndicators

--- a/src/containers/customer/products/info.tsx
+++ b/src/containers/customer/products/info.tsx
@@ -40,10 +40,8 @@ const ProductInfo = ({
           작가님께 신청자 정보를 간편하게 전달하기 위해 로그인을 해 주세요!
         </span>
         <LoginButton
-          type={{
-            roleType: "customer",
-            destination: `${profileName}/products/${productId}/reservation/reference`,
-          }}
+          roleType="customer"
+          destination={`${profileName}/products/${productId}/reservation/reference`}
         />
       </Modal>
       <Carousel

--- a/src/containers/photographer/login/index.tsx
+++ b/src/containers/photographer/login/index.tsx
@@ -2,10 +2,11 @@
 
 import ImageStack from "@/containers/common/image-stack/image-stack";
 import LoginInfo from "./info";
+import { loginStyles } from "./login.css";
 
 const Login = ({ images }: { images: string[] }) => {
   return (
-    <div style={{ width: "100%", maxWidth: 1000 }}>
+    <div className={loginStyles.layout}>
       <ImageStack images={images} />
       <LoginInfo />
     </div>

--- a/src/containers/photographer/login/info.tsx
+++ b/src/containers/photographer/login/info.tsx
@@ -8,7 +8,7 @@ const LoginInfo = () => {
       <span className={loginStyles.subtitle}>
         프리비와 함께 더 자유롭게 촬영하세요
       </span>
-      <LoginButton roleType="photographer" />
+      <LoginButton type={{ roleType: "photographer" }} />
     </div>
   );
 };

--- a/src/containers/photographer/login/info.tsx
+++ b/src/containers/photographer/login/info.tsx
@@ -8,7 +8,7 @@ const LoginInfo = () => {
       <span className={loginStyles.subtitle}>
         프리비와 함께 더 자유롭게 촬영하세요
       </span>
-      <LoginButton type={{ roleType: "photographer" }} />
+      <LoginButton roleType="photographer" destination="photographer" />
     </div>
   );
 };

--- a/src/containers/photographer/login/login.css.ts
+++ b/src/containers/photographer/login/login.css.ts
@@ -1,13 +1,31 @@
+import { breakpoints } from "@/styles/breakpoints.css";
 import sprinkles from "@/styles/sprinkles.css";
 import { texts } from "@/styles/text.css";
 import { styleVariants } from "@vanilla-extract/css";
 
 export const loginStyles = styleVariants({
+  layout: {
+    display: "flex",
+    flexWrap: "wrap",
+    width: "100%",
+    minHeight: "auto",
+    padding: "0px 100px",
+    columnGap: 50,
+
+    "@media": {
+      [breakpoints.mobile]: {
+        padding: 0,
+      },
+    },
+  },
   container: {
+    margin: "auto",
+    flexGrow: 0.7,
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    minWidth: "auto",
+    alignSelf: "center",
+    minWidth: "fit-content",
   },
   title: [
     texts["headline-02"],
@@ -20,5 +38,12 @@ export const loginStyles = styleVariants({
     sprinkles({
       color: "text-01",
     }),
+  ],
+  caption: [
+    texts["headline-03"],
+    sprinkles({
+      color: "text-03",
+    }),
+    { textDecoration: "underline", marginTop: 10 },
   ],
 });

--- a/src/containers/photographer/main/header.tsx
+++ b/src/containers/photographer/main/header.tsx
@@ -19,14 +19,23 @@ const Header = ({ isOnboarding }: { isOnboarding?: boolean }) => {
 
   return (
     <header className={styles.headerContainer}>
-      <Link href="/photographer" style={{ height: 20 }}>
+      {isOnboarding ? (
         <Image
           src="/icons/freebe-logo.svg"
           width={100}
           height={20}
           alt="free:be"
         />
-      </Link>
+      ) : (
+        <Link href="/photographer" style={{ height: 20 }}>
+          <Image
+            src="/icons/freebe-logo.svg"
+            width={100}
+            height={20}
+            alt="free:be"
+          />
+        </Link>
+      )}
       {!isOnboarding && (
         <>
           <Url myUrl={url} />

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,10 @@ export async function middleware(request: NextRequest) {
   const isLoggedIn = accessToken !== undefined;
   const isPhotographer = roleType === "photographer";
 
-  if (pathname.startsWith("/login")) {
+  if (
+    pathname.startsWith("/login") ||
+    pathname.startsWith("/photographer/join")
+  ) {
     if (isLoggedIn && isPhotographer) {
       return NextResponse.redirect(new URL("/photographer", request.url));
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,56 @@
 import { NextRequest, NextResponse } from "next/server";
+import { tokenKeys } from "./constants/auth";
 
 export async function middleware(request: NextRequest) {
-  return new NextResponse();
+  console.log("middleware run");
+  const url = request.nextUrl;
+  const { pathname } = url;
+
+  if (pathname.startsWith("/login/customer")) {
+    return NextResponse.next();
+  }
+
+  const accessToken = request.cookies.get(tokenKeys.access);
+  const roleType = request.cookies.get(tokenKeys.user)?.value;
+
+  const isLoggedIn = accessToken !== undefined;
+  const isPhotographer = roleType === "photographer";
+
+  if (pathname.startsWith("/login")) {
+    if (isLoggedIn && isPhotographer) {
+      return NextResponse.redirect(new URL("/photographer", request.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith("/photographer")) {
+    if (!isLoggedIn || !isPhotographer) {
+      return NextResponse.redirect(new URL("/login/photographer", request.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith("/customer")) {
+    if (!isLoggedIn) {
+      return NextResponse.redirect(
+        new URL(
+          `/login/customer?redirect=${encodeURIComponent(pathname)}`,
+          request.url,
+        ),
+      );
+    }
+    return NextResponse.next();
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {
-  matcher: "/about/:path*",
+  matcher: [
+    "/login",
+    "/login/customer",
+    "/login/photographer",
+    "/photographer/:path*",
+    "/customer/:path*",
+  ],
 };

--- a/src/services/server/core/auth.ts
+++ b/src/services/server/core/auth.ts
@@ -1,6 +1,12 @@
 import { cookies } from "next/headers";
 import { tokenKeys } from "@/constants/auth";
 import { redirect } from "next/navigation";
+import { User } from "user-types";
+
+export const setUserRole = (role: User) => {
+  const cookieStore = cookies();
+  cookieStore.set(tokenKeys.user, role);
+};
 
 export const getAccessToken = () => {
   const cookieStore = cookies();


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 페이지 접근시 로그인 여부 및 사용자 권한에 따라 적절히 리다이렉트 되도록 로직 추가
`login` 및 `login/photographer`: 사진작가 로그인 상태일 경우 → photographer로 이동
`photographer/`: 사진작가 로그인 상태가 아닐 경우 → login/photographer로 이동
`customer/`: 로그인 상태가 아닐 경우 → login/customer로 이동
* 헤더 리다이렉트 개선 (로그인 상태 반영)
* 의뢰자측 로그인 페이지의 경우 리다이렉트 이전에 접근하려던 경로를 저장해 로그인 후 destination으로 사용
* 그외 로그인 페이지 UI 개선

## 고민한 사항
* 이전에 로그인 페이지에서 로그인 버튼이 첫 화면 범위 내에 보이지 않는 것에 대한 피드백이 있어서 반응형 UI를 조금 개선해 봤습니다! 아직 스크롤해야 버튼이 보이는 경우도 있긴 하지만… 🥲

* 로컬에서는 로그인 에러가 발생하기 때문에 임시로 직접 토큰이나 role을 넣어서 테스트한 상태라, 배포 후에 추가로 테스트가 필요할 것 같습니다.
<img width="624" alt="스크린샷 2024-10-04 오후 6 04 20" src="https://github.com/user-attachments/assets/736da4f4-dd12-4099-82e7-68ff775ed365">


## 리뷰 요청사항
* 로그인 한 이후에 헤더에서 로고를 클릭하면 `/photographer` 메인 페이지로 연결되게 처리했는데, 로그인 이전 화면에서 (작가측 로그인 or 의뢰자측 로그인 or 작가측 회원가입) 로고를 클릭했을 때 어디로 보낼지는 조금 애매해서 일단 링크를 뗀 상태입니다. 혹시 마땅한 페이지가 있다면 의견 부탁드려요! 연결해 놓겠습니다

* `src/components/buttons/login-button.tsx`: 공통 로그인 버튼
로그인 이후 리다이렉트 시킬 url을 받아 카카오 로그인 요청시 state로 보냅니다.
`src/app/login/redirect/route.ts`:
로그인 api 요청 이후 결과에 따라 사용자 role을 함께 저장하도록 수정했습니다.
`src/middleware.ts`:
matcher에 정의된 패턴과 일치하는 url로 요청이 발생할 경우 로그인 여부 및 사용자 권한을 체크하고 필요시 리다이렉트합니다.

## 스크린샷
<img width="1407" alt="스크린샷 2024-10-04 오후 5 48 46" src="https://github.com/user-attachments/assets/e5437e58-8a1d-4d6b-9233-d59fb8c408ff">
(* 아직 리다이렉트가 아니라 직접 의뢰자 로그인 페이지에 접근해 로그인할 경우, 로그인 이후에 보내 줄 만한 화면이 없어서 작가측 로그인 페이지에는 "의뢰자로 로그인하기" 링크를 걸지 않았습니다.)