### PR TITLE
[FU-273] fix: clean old files before install

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -3,8 +3,6 @@ name: Frontend Dev Server CD
 on:
   push:
     branches: ["develop"]
-  pull_request:
-    branches: ["develop"]
 
 jobs:
   build:

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -3,7 +3,9 @@ name: Frontend Dev Server CD
 on:
   push:
     branches: ["develop"]
-  
+  pull_request:
+    branches: ["develop"]
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -14,7 +16,7 @@ jobs:
 
       - name: Check Node v
         run: node -v
-        
+
       - name: env 설정
         run: |
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env

--- a/appspec.yml
+++ b/appspec.yml
@@ -13,14 +13,18 @@ permissions:
     owner: ubuntu
     group: ubuntu
 
-hooks: 
+hooks:
+  BeforeInstall:
+    - location: scripts/clean_old_files.sh
+      timeout: 120
+      runas: root
+
   ApplicationStop:
     - location: scripts/stop.sh
       timeout: 60
-      runas : root
-      
+      runas: root
+
   ApplicationStart:
     - location: scripts/start.sh
       timeout: 600
-      runas : root
-    
+      runas: root

--- a/scripts/clean_old_files.sh
+++ b/scripts/clean_old_files.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo rm -rf /home/ubuntu/freebe-frontend/*


### PR DESCRIPTION
### 1. 현상 파악

* https://github.com/SWM-15th-ForU/freebe-frontend/pull/42 병합 및 자동 배포 이후 502 bad gateway 발생


### 2. 분석하기

* pm2 status 확인 결과 online으로 정상 동작 중, 검색 등록 및 랜딩 페이지 연결 등 도메인 설정 변경으로 인한 문제를 의심함 
* 빌드 자체의 문제임을 확인

> 로드 밸런서 프론트엔드 그룹에서 health 체크 실패
ec2 퍼블릭 ip로 직접 접근 시에도 연결 불가
한 시간 가량 ec2 CPU 사용량이 50% 대에서 떨어지지 않음

* pm2 status에서 retry 횟수가 계속해서 증가 중인 것을 발견하고 pm2 log 확인 결과 계속해서 process kill과 재시작이 반복되고 있었음
* 직접 빌드해 restart를 진행해 보려 하였으나 빌드 에러 발생
* git log를 통해 HEAD 자체는 같은 곳을 가리키고 있음에도, 해당 커밋에서 삭제된 파일 및 폴더가 ec2에서는 남아 있음을 확인
* `@modal` 폴더가 삭제되지 않아 빌드 에러가 발생한 것을 파악할 수 있었음

### 3. 조치하기
* 자동 배포 과정에서 기존에 이미 존재하는 파일은 overwrite를 통해 정상적으로 최신 버전을 반영할 수 있지만, 원격 레포지토리에서 삭제된 파일에 대한 반영이 되지 않는 다는 점을 확인하였습니다. 따라서 code deploy 이벤트 중 BeforeInstall hook으로 기존 폴더를 삭제하는 스크립트를 추가하였습니다.

### 4. 검증하기
* BeforeInstall에서 매번 기존 폴더를 삭제할 경우 .gitignore로 관리되는 파일을 ec2에서 직접 생성해 사용 중이라면 문제가 될 수 있다는 점을 확인하였으나, 현재 cd workflow에서 환경변수를 포함해 주고 있으므로 문제가 생기지 않을 것으로 보입니다.
* workflow를 수정하고 script를 추가한 상태에서 cd가 성공하였고, 삭제된 파일 역시 ec2에서 정상적으로 삭제되었음을 확인하였습니다. 👍
* 이후 서비스 정상적으로 접근되고, health 체크 성공한 것 확인하였습니다.

### 5. 회고
* 이전 폴더를 확실히 삭제하고 코드를 가져옴으로써 배포 버전에 좀 더 확실하게 최신 수정사항을 반영할 수 있는 흐름을 구성하게 되어 다행인 것 같습니다. 앞으로 환경변수 변경 시에만 놓치는 일 없이 잘 연결해 주면 될 것 같습니다!
* code deploy에서 에러가 발생하지 않아 직접 접속하기 전까지는 에러 발생을 알지 못했고, 초반에는 빌드 - 배포가 아닌 다른 쪽에서 문제가 발생한 것으로 의심했습니다. 지난번에 한 번 언급되었던 AWS 모니터링의 필요성을 느꼈습니다…! 😂

