### PR TITLE
[FU-288] user role setting

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -3,6 +3,9 @@ name: Frontend Dev Server CD
 on:
   push:
     branches: ["develop"]
+  # TODO: 테스트 후 제거
+  pull_request:
+    branches: ["develop"]
 
 jobs:
   build:

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -3,9 +3,6 @@ name: Frontend Dev Server CD
 on:
   push:
     branches: ["develop"]
-  # TODO: 테스트 후 제거
-  pull_request:
-    branches: ["develop"]
 
 jobs:
   build:

--- a/src/app/auth/role/route.ts
+++ b/src/app/auth/role/route.ts
@@ -1,0 +1,23 @@
+import { setUserRole } from "@/services/server/core/auth";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const allowedOrigins = [process.env.NEXT_PUBLIC_DOMAIN];
+  const origin = request.headers.get("origin")?.concat("/");
+
+  if (origin && !allowedOrigins.includes(origin)) {
+    console.log(origin);
+    return new NextResponse("CORS Error: request from not allowed domain", {
+      status: 403,
+    });
+  }
+  try {
+    const { role } = (await request.json()) as {
+      role: "photographer" | "customer";
+    };
+    setUserRole(role);
+  } catch (error) {
+    return NextResponse.json({}, { status: 400 });
+  }
+  return NextResponse.json({}, { status: 200 });
+}

--- a/src/app/login/redirect/route.ts
+++ b/src/app/login/redirect/route.ts
@@ -28,7 +28,6 @@ export async function GET(request: NextRequest) {
 
   function getRedirectDestination(responseMessage: string): string {
     if (responseMessage === "photographer join") {
-      setUserRole("photographer");
       return "photographer/join";
     }
     if (responseMessage === "photographer login") {

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -13,5 +13,5 @@ export const METADATA = {
     "스냅사진 예약",
   ],
   favicon: "/favicon.ico",
-  ogImage: "/images/opengraph.png",
+  ogImage: `${process.env.NEXT_PUBLIC_DOMAIN}/images/opengraph.png`,
 };

--- a/src/containers/customer/products/info.tsx
+++ b/src/containers/customer/products/info.tsx
@@ -58,8 +58,7 @@ const ProductInfo = ({
               style={{
                 position: "relative",
                 width: "100%",
-                height: "auto",
-                minHeight: "40vh",
+                height: "100vw",
                 backgroundColor: "#d9d9d9",
               }}
             >
@@ -71,7 +70,10 @@ const ProductInfo = ({
       <div className={infoStyles.wrapper}>
         <div className={infoStyles.headWrapper}>
           <span className={infoStyles.title}>{title}</span>
-          <span className={infoStyles.price}>{formatPrice(basicPrice)}~</span>
+          <span className={infoStyles.price}>
+            {formatPrice(basicPrice)}
+            {basicPrice !== 0 && "~"}
+          </span>
         </div>
         <p className={infoStyles.content}>{subtitle}</p>
       </div>
@@ -90,7 +92,11 @@ const ProductInfo = ({
           })}
         </div>
       </div>
-      <BottomButton title="예약 시작하기" onClick={open} />
+      <BottomButton
+        title="예약 시작하기"
+        onClick={open}
+        style={{ position: "fixed" }}
+      />
     </div>
   );
 };

--- a/src/containers/photographer/join/index.tsx
+++ b/src/containers/photographer/join/index.tsx
@@ -9,7 +9,7 @@ import { ID_REGEX } from "@/constants/common/user";
 import popToast from "@/components/common/toast";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import { postProfile } from "@/services/client/photographer/profile";
-import { responseHandler } from "@/services/common/error";
+import { CUSTOMED_CODE, responseHandler } from "@/services/common/error";
 import Profile from "./profile";
 import Agreements from "./agreements";
 import { joinStyles } from "./join.css";
@@ -39,11 +39,22 @@ const PhotographerJoin = () => {
     defaultValues,
     resolver: zodResolver(joinSchema),
   });
-  const { handleSubmit, watch } = method;
+  const { handleSubmit, watch, setError } = method;
   const [serviceAgreement, privacyAgreement] = watch([
     "serviceAgreement",
     "privacyAgreement",
   ]);
+
+  function handleSubmitFail(message?: string) {
+    if (message === CUSTOMED_CODE.PROFILE_NAME_ALREADY_EXISTS) {
+      setError(
+        "profileName",
+        { message: "아이디를 다시 설정해주세요." },
+        { shouldFocus: true },
+      );
+    }
+    popToast("다시 시도해 주세요.", message || "가입에 실패했습니다.", true);
+  }
 
   async function onSubmit(data: Join) {
     await responseHandler(
@@ -52,8 +63,7 @@ const PhotographerJoin = () => {
         popToast("가입이 완료되었습니다!");
         router.push(`/photographer?url=${url}`);
       },
-      (message) =>
-        popToast("다시 시도해 주세요.", message || "가입에 실패했습니다."),
+      handleSubmitFail,
     );
   }
 

--- a/src/containers/photographer/product/product-list.tsx
+++ b/src/containers/photographer/product/product-list.tsx
@@ -2,11 +2,12 @@
 
 import Link from "next/link";
 import { Status } from "product-types";
+import { ProductResponseData } from "@/services/server/photographer/mypage/products";
 import ProductBanner from "./list/product-banner";
 import { listStyles } from "./product.css";
 
 interface ProductListProps {
-  productDatas: Parameters<typeof ProductBanner>[0][];
+  productDatas: ProductResponseData[];
   status: Status;
   height?: number;
 }

--- a/src/services/client/photographer/profile.ts
+++ b/src/services/client/photographer/profile.ts
@@ -13,5 +13,11 @@ export async function postProfile(form: Join) {
       json: body,
     })
     .json<{ data: string }>();
+  await fetch(`${process.env.NEXT_PUBLIC_DOMAIN}auth/role`, {
+    method: "POST",
+    body: JSON.stringify({
+      role: "photographer",
+    }),
+  });
   return data;
 }

--- a/src/services/common/error.ts
+++ b/src/services/common/error.ts
@@ -4,7 +4,7 @@ export interface CustomedError extends HTTPError {
   customedMessage?: string;
 }
 
-const CUSTOMED_CODE: { [key: string]: string } = {
+export const CUSTOMED_CODE: { [key: string]: string } = {
   PROFILE_NAME_ALREADY_EXISTS: "이미 존재하는 프로필명입니다.",
   PRODUCT_ALREADY_EXISTS: "이미 존재하는 상품입니다.",
   INVALID_MEMBER_ROLE_TYPE: "잘못된 아이디입니다.",


### PR DESCRIPTION
## 1. 현상 파악
* 프론트엔드에서 middleware를 활용해 userRole / accessToken 기반의 리다이렉트 로직을 구현한 이후, 가입 플로우를 거치게 되자 `photographer/join`으로 넘어가지 않고 바로 `photographer` 페이지로 이동하며 user url이 나타나지 않는 문제 발생

## 2. 분석하기
* 네트워크 기록상 `photographer/join`에서 `photographer`로 리다이렉트가 발생하고 있는 것으로 파악
* 미들웨어 로직을 재검토한 결과, "사진작가 role로" "로그인이 완료되었을 경우" `photographer/join`에 접근하지 않도록 리다이렉트 시키고 있었고 이 부분이 동작하면서 위와 같은 상황이 나타난 것으로 이해
* accessToken 세팅이 join api 성공 이후에 이루어진다고 착각하고 있어 `PHOTOGRAPHER_PENDING`으로 로그인되는 시점에 role까지 같이 세팅해 버리면서 미들웨어 분기에 들어가게 되었음

## 3. 조치하기
* 분석한 결과를 고려했을 때, 유저가 사진작가 가입을 진행할 시 적절한 흐름은 아래와 같았습니다.

[![](https://mermaid.ink/img/pako:eNqVks1KAzEUhV_lkpVi-wKzEARFXahFXUlA4kxsRzvJmEkWIoJCXWhFLYjW2opC0Y2CSMURfKIm8w4m1RH82QhZJHPOufmYnC3k84AiDyV0Q1Hm0_GQlAWJMCNKcqaiFSowwwwAYiJk6IcxYRIUkARUQgUMlabmFucm58dKUxPzy6WJ2fHp2cnhXwHfBVYFZ5Ky4JeaOHWF-Ou5-HmlKo6OjvgemNeeW80u6Jt2_yU1nRRMvW2uGgOb72yJB1VeDhmQOATTOjVPDwMxKVq16IZ0Grr-DPqxmV00YSjb7enOm-n0zFmaHdh56Y05PzG1NkhuOcDU0uxwb_jzAjdDeZC1Ds3lSf9xx1ztQXbUdPG7HQsF-vZe17v2rK_37TjMcvZvEQutj2uY5cRr_Afw_2kFr9K_YeMKl9w-ZlyhwiFat36tmYMumOtG_-XN_WRUQBEVEQkD24Etl8dIVmhEMfLsNiBiHSPMtq3PFWJhk_nIk0LRAhJclSvIWyXVxJ5UHBCZt-frKw1CycXMR8UGTSsg--JLnOee7XcgyRol?type=png)](https://mermaid.live/edit#pako:eNqVks1KAzEUhV_lkpVi-wKzEARFXahFXUlA4kxsRzvJmEkWIoJCXWhFLYjW2opC0Y2CSMURfKIm8w4m1RH82QhZJHPOufmYnC3k84AiDyV0Q1Hm0_GQlAWJMCNKcqaiFSowwwwAYiJk6IcxYRIUkARUQgUMlabmFucm58dKUxPzy6WJ2fHp2cnhXwHfBVYFZ5Ky4JeaOHWF-Ou5-HmlKo6OjvgemNeeW80u6Jt2_yU1nRRMvW2uGgOb72yJB1VeDhmQOATTOjVPDwMxKVq16IZ0Grr-DPqxmV00YSjb7enOm-n0zFmaHdh56Y05PzG1NkhuOcDU0uxwb_jzAjdDeZC1Ds3lSf9xx1ztQXbUdPG7HQsF-vZe17v2rK_37TjMcvZvEQutj2uY5cRr_Afw_2kFr9K_YeMKl9w-ZlyhwiFat36tmYMumOtG_-XN_WRUQBEVEQkD24Etl8dIVmhEMfLsNiBiHSPMtq3PFWJhk_nIk0LRAhJclSvIWyXVxJ5UHBCZt-frKw1CycXMR8UGTSsg--JLnOee7XcgyRol)

* 다만, (6) join api 요청을 현재 클라이언트 측에서 보내고 있기 때문에 (2 ~ 4번은 모두 서버 사이드에서 진행하고 있었습니다.) 성공 이후 role을 바로 세팅하는 데 어려움이 발생했습니다.
* `photographer/join`을 middleware 처리 범위에서 제거하는 것도 고민하였으나, 추후 인증/인가 방식에 변경이나 확장이 발생할 경우 관리가 더 어려워질 수 있다는 점을 고려했습니다.
* 별도의 route handler를 만들고 join api 시도가 완료될 경우 **해당 위치로 user role 세팅을 요청하는 것까지 끝낸 뒤에** join 성공으로 판단하여 `/photographer`로 이동해 주도록 수정하였습니다.

## 4. 검증하기
배포 환경에서 사진작가 가입 플로우에 대한 검증을 마쳤습니다.

## 5. 회고
photographer join의 경우에도 join이 아닌 login api 이후에 토큰을 받아오고 있었는데 이 부분을 착각해서 문제가 발생했습니다… 😓 @rheeri 조치 과정에서 도와줘서 감사합니다 🙇💖 
