### PR TITLE
[FU-286] reservation filter

### DIFF
--- a/src/components/common/common.css.ts
+++ b/src/components/common/common.css.ts
@@ -134,7 +134,7 @@ export const searchStyles = styleVariants({
       alignItems: "center",
       gap: 4,
       ":focus-within": {
-        outline: "1px solid #007AFF",
+        border: "1px solid #007AFF",
       },
     },
   ],
@@ -297,7 +297,7 @@ export const filterStyles = styleVariants({
     display: "flex",
     flexDirection: "column",
     gap: 16,
-    margin: "16px 0px",
+    marginBottom: 16,
     height: "auto",
     maxHeight: 216,
     overflowY: "scroll",

--- a/src/components/common/filter-product.tsx
+++ b/src/components/common/filter-product.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { FilterItemType } from "common-types";
+import { Menu } from "@mantine/core";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getProductTitles } from "@/services/client/photographer/products";
+import Check from "../inputs/check";
+import Search from "./search";
+import { chipStyles, filterStyles } from "./common.css";
+
+interface FilterProductProps {
+  selectedItems: string[];
+  onSelect: (title: string) => void;
+  hasSearch?: boolean;
+  children?: React.ReactNode;
+}
+
+const FilterItem = ({
+  item,
+  selected,
+  onClickItem,
+}: {
+  item: FilterItemType;
+  onClickItem: () => void;
+  selected: boolean;
+}) => {
+  return (
+    <button className={filterStyles.item} onClick={onClickItem} type="button">
+      <Check onPress={() => {}} value={selected} />
+      {item.name}
+    </button>
+  );
+};
+
+const FilterProduct = ({
+  onSelect,
+  selectedItems,
+  hasSearch,
+  children,
+}: FilterProductProps) => {
+  const [search, setSearch] = useState("");
+  const { data, error } = useSuspenseQuery({
+    queryKey: ["productTitle"],
+    initialData: [],
+    staleTime: 0,
+    queryFn: () => getProductTitles(),
+    retry: false,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  function getSearchList() {
+    return search.length > 0
+      ? data.filter((item) =>
+          item.name.toLowerCase().includes(search.toLowerCase()),
+        )
+      : data;
+  }
+
+  return (
+    <Menu position="top-start">
+      <Menu.Target>
+        <button
+          type="button"
+          className={
+            selectedItems.length > 0
+              ? chipStyles.selectedContainer
+              : chipStyles.normal
+          }
+        >
+          <Image
+            src={
+              selectedItems.length > 0
+                ? "/icons/filter.svg"
+                : "/icons/filter-blue.svg"
+            }
+            alt="필터"
+            width={24}
+            height={24}
+          />
+          <span>필터</span>
+          {selectedItems.length > 0 && (
+            <span className={chipStyles.caption}>{selectedItems.length}</span>
+          )}
+        </button>
+      </Menu.Target>
+      <Menu.Dropdown classNames={{ dropdown: filterStyles.dropdown }}>
+        {hasSearch && <Search value={search} setValue={setSearch} />}
+        <div className={filterStyles.list}>
+          {(hasSearch ? getSearchList() : data).map((item) => {
+            return (
+              <FilterItem
+                key={item.id}
+                item={item}
+                selected={selectedItems.includes(item.name)}
+                onClickItem={() => onSelect(item.name)}
+              />
+            );
+          })}
+        </div>
+        {children && <Menu.Divider />}
+        {children}
+      </Menu.Dropdown>
+    </Menu>
+  );
+};
+
+export default FilterProduct;

--- a/src/components/common/filter-product.tsx
+++ b/src/components/common/filter-product.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { FilterItemType } from "common-types";
 import { Menu } from "@mantine/core";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import QueryProviders from "@/containers/common/query-providers";
 import { getProductTitles } from "@/services/client/photographer/products";
 import Check from "../inputs/check";
 import Search from "./search";
@@ -13,7 +14,6 @@ import { chipStyles, filterStyles } from "./common.css";
 interface FilterProductProps {
   selectedItems: string[];
   onSelect: (title: string) => void;
-  hasSearch?: boolean;
   children?: React.ReactNode;
 }
 
@@ -34,12 +34,10 @@ const FilterItem = ({
   );
 };
 
-const FilterProduct = ({
-  onSelect,
+const FilterList = ({
   selectedItems,
-  hasSearch,
-  children,
-}: FilterProductProps) => {
+  onSelect,
+}: Omit<FilterProductProps, "children">) => {
   const [search, setSearch] = useState("");
   const { data, error } = useSuspenseQuery({
     queryKey: ["productTitle"],
@@ -61,6 +59,28 @@ const FilterProduct = ({
       : data;
   }
 
+  return (
+    <div className={filterStyles.list}>
+      <Search value={search} setValue={setSearch} />
+      {getSearchList().map((item) => {
+        return (
+          <FilterItem
+            key={item.id}
+            item={item}
+            selected={selectedItems.includes(item.name)}
+            onClickItem={() => onSelect(item.name)}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+const FilterProduct = ({
+  onSelect,
+  selectedItems,
+  children,
+}: FilterProductProps) => {
   return (
     <Menu position="top-start">
       <Menu.Target>
@@ -89,19 +109,9 @@ const FilterProduct = ({
         </button>
       </Menu.Target>
       <Menu.Dropdown classNames={{ dropdown: filterStyles.dropdown }}>
-        {hasSearch && <Search value={search} setValue={setSearch} />}
-        <div className={filterStyles.list}>
-          {(hasSearch ? getSearchList() : data).map((item) => {
-            return (
-              <FilterItem
-                key={item.id}
-                item={item}
-                selected={selectedItems.includes(item.name)}
-                onClickItem={() => onSelect(item.name)}
-              />
-            );
-          })}
-        </div>
+        <QueryProviders>
+          <FilterList selectedItems={selectedItems} onSelect={onSelect} />
+        </QueryProviders>
         {children && <Menu.Divider />}
         {children}
       </Menu.Dropdown>

--- a/src/containers/photographer/list/index.tsx
+++ b/src/containers/photographer/list/index.tsx
@@ -5,7 +5,11 @@ import { responseHandler } from "@/services/common/error";
 import StatusList from "./status-list";
 import { viewContainer } from "./list.css";
 
-const ReservationList = () => {
+const ReservationList = ({
+  selectedProducts,
+}: {
+  selectedProducts: string[];
+}) => {
   const [datas, setDatas] = useState<{ [key in ActiveStatus]: Infos[] }>({
     NEW: [],
     IN_PROGRESS: [],
@@ -20,17 +24,32 @@ const ReservationList = () => {
     fetchData();
   }, []);
 
+  function getSelectedReservations(reservations: Infos[]) {
+    if (selectedProducts.length === 0) {
+      return reservations;
+    }
+    return reservations.filter((reservation) =>
+      selectedProducts.includes(reservation.productTitle),
+    );
+  }
+
   return (
     <div className={viewContainer}>
-      <StatusList status="NEW" reservations={datas.NEW} />
-      <StatusList status="IN_PROGRESS" reservations={datas.IN_PROGRESS} />
+      <StatusList
+        status="NEW"
+        reservations={getSelectedReservations(datas.NEW)}
+      />
+      <StatusList
+        status="IN_PROGRESS"
+        reservations={getSelectedReservations(datas.IN_PROGRESS)}
+      />
       <StatusList
         status="WAITING_FOR_DEPOSIT"
-        reservations={datas.WAITING_FOR_DEPOSIT}
+        reservations={getSelectedReservations(datas.WAITING_FOR_DEPOSIT)}
       />
       <StatusList
         status="WAITING_FOR_PHOTO"
-        reservations={datas.WAITING_FOR_PHOTO}
+        reservations={getSelectedReservations(datas.WAITING_FOR_PHOTO)}
       />
     </div>
   );

--- a/src/containers/photographer/main/controller.tsx
+++ b/src/containers/photographer/main/controller.tsx
@@ -1,45 +1,36 @@
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { MainViewType } from "service-types";
 import { MenuItem } from "@mantine/core";
-import Filter from "@/components/common/filter";
 import Slider from "@/components/common/slider";
+import FilterProduct from "@/components/common/filter-product";
+import QueryProviders from "@/containers/common/query-providers";
 import { mainviewStyles } from "./main.css";
-
-interface FilterItem {
-  id: string;
-  name: string;
-  selected: boolean;
-}
 
 interface ControllerProps {
   view: MainViewType;
   setView: Dispatch<SetStateAction<MainViewType>>;
+  selectedProducts: string[];
+  setSelectedProducts: Dispatch<SetStateAction<string[]>>;
 }
 
-const Controller = ({ view, setView }: ControllerProps) => {
-  const [filterList, setFilterList] = useState<FilterItem[]>([
-    { id: "1", name: "상품 1", selected: false },
-    { id: "2", name: "상품 2", selected: false },
-    { id: "3", name: "상품 3", selected: false },
-  ]);
-
+const Controller = ({
+  view,
+  setView,
+  selectedProducts,
+  setSelectedProducts,
+}: ControllerProps) => {
   function handleChangeView(id: string) {
     if (id === "list" || id === "calender") setView(id);
   }
 
-  function handleFilterChange(itemId: string) {
-    setFilterList((prevList) => {
-      return prevList.map((item) => {
-        if (item.id === itemId) {
-          return {
-            ...item,
-            selected: !item.selected,
-          };
-        }
-        return item;
-      });
+  function handleFilterChange(selectedName: string) {
+    setSelectedProducts((prev) => {
+      if (prev.includes(selectedName)) {
+        return prev.filter((product) => product !== selectedName);
+      }
+      return [...prev, selectedName];
     });
   }
 
@@ -53,22 +44,23 @@ const Controller = ({ view, setView }: ControllerProps) => {
         defaultId={view}
         onChange={handleChangeView}
       />
-      <Filter
-        items={filterList}
-        onSelect={handleFilterChange}
-        selectedItems={filterList.filter((item) => item.selected)}
-        hasSearch
-      >
-        <MenuItem style={{ marginTop: 16 }}>
-          <Link
-            href="/photographer/new-product"
-            className={mainviewStyles.link}
-          >
-            <Image src="/icons/plus.svg" width={12} height={12} alt="추가" />
-            상품 추가하기
-          </Link>
-        </MenuItem>
-      </Filter>
+      <QueryProviders>
+        <FilterProduct
+          onSelect={handleFilterChange}
+          selectedItems={selectedProducts}
+          hasSearch
+        >
+          <MenuItem style={{ marginTop: 16 }}>
+            <Link
+              href="/photographer/new-product"
+              className={mainviewStyles.link}
+            >
+              <Image src="/icons/plus.svg" width={12} height={12} alt="추가" />
+              상품 추가하기
+            </Link>
+          </MenuItem>
+        </FilterProduct>
+      </QueryProviders>
     </div>
   );
 };

--- a/src/containers/photographer/main/controller.tsx
+++ b/src/containers/photographer/main/controller.tsx
@@ -44,23 +44,20 @@ const Controller = ({
         defaultId={view}
         onChange={handleChangeView}
       />
-      <QueryProviders>
-        <FilterProduct
-          onSelect={handleFilterChange}
-          selectedItems={selectedProducts}
-          hasSearch
-        >
-          <MenuItem style={{ marginTop: 16 }}>
-            <Link
-              href="/photographer/new-product"
-              className={mainviewStyles.link}
-            >
-              <Image src="/icons/plus.svg" width={12} height={12} alt="추가" />
-              상품 추가하기
-            </Link>
-          </MenuItem>
-        </FilterProduct>
-      </QueryProviders>
+      <FilterProduct
+        onSelect={handleFilterChange}
+        selectedItems={selectedProducts}
+      >
+        <MenuItem style={{ marginTop: 16 }}>
+          <Link
+            href="/photographer/new-product"
+            className={mainviewStyles.link}
+          >
+            <Image src="/icons/plus.svg" width={12} height={12} alt="추가" />
+            상품 추가하기
+          </Link>
+        </MenuItem>
+      </FilterProduct>
     </div>
   );
 };

--- a/src/containers/photographer/main/index.tsx
+++ b/src/containers/photographer/main/index.tsx
@@ -9,11 +9,19 @@ import { mainviewStyles } from "./main.css";
 
 const MainView = () => {
   const [view, setView] = useState<MainViewType>("list");
+  const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
 
   return (
     <div className={mainviewStyles.container}>
-      <Controller view={view} setView={setView} />
-      {view === "list" && <ReservationList />}
+      <Controller
+        view={view}
+        setView={setView}
+        selectedProducts={selectedProducts}
+        setSelectedProducts={setSelectedProducts}
+      />
+      {view === "list" && (
+        <ReservationList selectedProducts={selectedProducts} />
+      )}
       {view === "calender" && <Preparing />}
     </div>
   );

--- a/src/services/client/photographer/products.ts
+++ b/src/services/client/photographer/products.ts
@@ -1,5 +1,18 @@
 import { FormImage, ProductFormdata } from "product-types";
+import { FilterItemType } from "common-types";
 import apiClient from "../core";
+
+export async function getProductTitles(): Promise<FilterItemType[]> {
+  const { data } = await apiClient.get("photographer/product/title").json<{
+    data: {
+      title: string;
+    }[];
+  }>();
+
+  return data.map(({ title }, index) => {
+    return { name: title, id: index };
+  });
+}
 
 export async function postNewProduct(
   form: ProductFormdata,

--- a/src/types/common-types.d.ts
+++ b/src/types/common-types.d.ts
@@ -3,4 +3,9 @@ declare module "common-types" {
     total: number;
     current: number;
   }
+
+  interface FilterItemType {
+    id: number;
+    name: string;
+  }
 }


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 상품 이름 목록 조회 api 연결
* 메인 화면에서 상품을 통한 필터링 기능 추가

## 고민한 사항
* 기존에 임시로 만들어 뒀던 Filter 컴포넌트와 방식의 차이가 생겨서 (기존: 상위에서 필터링 목록 데이터를 내려줌 / 실제 구현: 바운더리 처리를 위해 상품 제목 리스트 범위까지 묶고 내부에서 api 호출) 리팩토링이 좀 필요했는데 일단은 기존 Filter 컴포넌트의 보다 커스텀된 버전인 FilterProduct를 따로 만들어서 해결했습니다…! 😌

## 리뷰 요청사항
* 시급도: `보통`
* `src/services/client/photographer/products.ts`: 상품 제목 리스트 조회
* `src/components/common/filter-product.tsx`: api 호출 위치 및 필터링 컴포넌트 (바운더리를 자르느라 한 파일 안에서 세 번 분리됐습니다,,)

## 스크린샷
![FU-286](https://github.com/user-attachments/assets/23e7bfd3-4908-400f-9e4e-51b12a9edbc1)
(신청서 데이터가 많이 쌓여 있지 않아서 더미 데이터 사용해 테스트했습니다.)

[FU-286]: https://for-u.atlassian.net/browse/FU-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
