### PR TITLE
[FU-290] photographer contact

### DIFF
--- a/src/components/inputs/input.css.ts
+++ b/src/components/inputs/input.css.ts
@@ -211,7 +211,15 @@ const InputStyles = styleVariants({
       marginRight: "auto",
     },
   ],
-  multilineInput: [baseInput, { maxWidth: "100%", minHeight: "35px" }],
+  multilineInput: [
+    baseInput,
+    {
+      maxWidth: "100%",
+      boxSizing: "border-box",
+      minHeight: "30px",
+      resize: "vertical",
+    },
+  ],
 });
 
 export default InputStyles;

--- a/src/components/inputs/input.css.ts
+++ b/src/components/inputs/input.css.ts
@@ -211,7 +211,7 @@ const InputStyles = styleVariants({
       marginRight: "auto",
     },
   ],
-  multilineInput: [baseInput],
+  multilineInput: [baseInput, { maxWidth: "100%", minHeight: "35px" }],
 });
 
 export default InputStyles;

--- a/src/containers/photographer/join/index.tsx
+++ b/src/containers/photographer/join/index.tsx
@@ -25,11 +25,16 @@ const PhotographerJoin = () => {
       .regex(ID_REGEX, {
         message: "아이디에는 특수문자를 포함할 수 없습니다.",
       }),
+    contact: z
+      .string()
+      .min(1, { message: "연락처를 입력해 주세요." })
+      .max(100, { message: "최대 100자까지 입력 가능합니다." }),
     marketingAgreement: z.boolean(),
     privacyAgreement: z.boolean(),
     serviceAgreement: z.boolean(),
   });
   const defaultValues: Join = {
+    contact: "",
     profileName: "",
     marketingAgreement: false,
     privacyAgreement: false,

--- a/src/containers/photographer/join/profile.tsx
+++ b/src/containers/photographer/join/profile.tsx
@@ -28,6 +28,24 @@ const Profile = () => {
           {errors.profileName.message}
         </span>
       )}
+      <TextInput<Join>
+        title="연락처"
+        placeholder="연락처를 입력해주세요."
+        formField="contact"
+        multiline
+        container={{ marginBottom: 10 }}
+      />
+      <div className={profileStyles.caption}>
+        <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
+        <span>
+          설정한 연락처는 작가님과 예약을 확정한 고객에게만 전달되며, 이후에도
+          수정 가능합니다. 고객이 연락할 수 있는 수단을 등록해주세요. (전화번호,
+          오픈채팅방 링크, 인스타그램 DM 등)
+        </span>
+      </div>
+      {errors.contact && (
+        <span className={profileStyles.error}>{errors.contact.message}</span>
+      )}
     </div>
   );
 };

--- a/src/containers/photographer/join/profile.tsx
+++ b/src/containers/photographer/join/profile.tsx
@@ -30,7 +30,7 @@ const Profile = () => {
       )}
       <TextInput<Join>
         title="연락처"
-        placeholder="연락처를 입력해주세요."
+        placeholder="고객이 연락할 수 있는 수단을 입력해주세요."
         formField="contact"
         multiline
         container={{ marginBottom: 10 }}
@@ -38,9 +38,8 @@ const Profile = () => {
       <div className={profileStyles.caption}>
         <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
         <span>
-          설정한 연락처는 작가님과 예약을 확정한 고객에게만 전달되며, 이후에도
-          수정 가능합니다. 고객이 연락할 수 있는 수단을 등록해주세요. (전화번호,
-          오픈채팅방 링크, 인스타그램 DM 등)
+          설정한 연락처는(전화번호, 카카오톡 채팅방 링크, 인스타그램 아이디 등)
+          작가님께서 예약을 수락하신 고객에게만 전달됩니다.
         </span>
       </div>
       {errors.contact && (

--- a/src/containers/photographer/mypage/profile/edit/basic-info.tsx
+++ b/src/containers/photographer/mypage/profile/edit/basic-info.tsx
@@ -65,7 +65,7 @@ const BasicInfo = () => {
         />
         <TextInput<PhotographerForm>
           title="연락처"
-          placeholder="연락처를 입력해주세요."
+          placeholder="고객이 연락할 수 있는 수단을 입력해주세요."
           formField="contact"
           multiline
           container={{ marginBottom: 10 }}
@@ -73,9 +73,8 @@ const BasicInfo = () => {
         <div className={editStyles.caption}>
           <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
           <span>
-            설정한 연락처는 작가님과 예약을 확정한 고객에게만 전달됩니다. 고객이
-            연락할 수 있는 수단을 등록해주세요. (전화번호, 오픈채팅방 링크,
-            인스타그램 DM 등)
+            설정한 연락처는(전화번호, 카카오톡 채팅방 링크, 인스타그램 아이디
+            등) 작가님께서 예약을 수락하신 고객에게만 전달됩니다.
           </span>
         </div>
         {errors.contact && (

--- a/src/containers/photographer/mypage/profile/edit/basic-info.tsx
+++ b/src/containers/photographer/mypage/profile/edit/basic-info.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent } from "react";
+import Image from "next/image";
 import { useFormContext } from "react-hook-form";
 import { PhotographerForm } from "profile-types";
 import TextInput from "@/components/inputs/text-input";
@@ -7,7 +8,11 @@ import { CustomButton } from "@/components/buttons/common-buttons";
 import { editStyles } from "./edit.css";
 
 const BasicInfo = () => {
-  const { watch, setValue } = useFormContext<PhotographerForm>();
+  const {
+    watch,
+    setValue,
+    formState: { errors },
+  } = useFormContext<PhotographerForm>();
   const profileImg = watch("profileImg");
 
   function handleChangeProfileImg(e: ChangeEvent<HTMLInputElement>) {
@@ -59,12 +64,33 @@ const BasicInfo = () => {
           container={{ marginTop: 0 }}
         />
         <TextInput<PhotographerForm>
+          title="연락처"
+          placeholder="연락처를 입력해주세요."
+          formField="contact"
+          multiline
+          container={{ marginBottom: 10 }}
+        />
+        <div className={editStyles.caption}>
+          <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
+          <span>
+            설정한 연락처는 작가님과 예약을 확정한 고객에게만 전달되며, 이후에도
+            수정 가능합니다. 고객이 연락할 수 있는 수단을 등록해주세요.
+            (전화번호, 오픈채팅방 링크, 인스타그램 DM 등)
+          </span>
+        </div>
+        {errors.contact && (
+          <span className={editStyles.error}>{errors.contact.message}</span>
+        )}
+        <TextInput<PhotographerForm>
           title="소개 문구"
           placeholder="소개글을 입력해 주세요."
           formField="message"
           inputSize="md"
           multiline
         />
+        {errors.message && (
+          <span className={editStyles.error}>{errors.message.message}</span>
+        )}
       </div>
     </div>
   );

--- a/src/containers/photographer/mypage/profile/edit/basic-info.tsx
+++ b/src/containers/photographer/mypage/profile/edit/basic-info.tsx
@@ -73,9 +73,9 @@ const BasicInfo = () => {
         <div className={editStyles.caption}>
           <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
           <span>
-            설정한 연락처는 작가님과 예약을 확정한 고객에게만 전달되며, 이후에도
-            수정 가능합니다. 고객이 연락할 수 있는 수단을 등록해주세요.
-            (전화번호, 오픈채팅방 링크, 인스타그램 DM 등)
+            설정한 연락처는 작가님과 예약을 확정한 고객에게만 전달됩니다. 고객이
+            연락할 수 있는 수단을 등록해주세요. (전화번호, 오픈채팅방 링크,
+            인스타그램 DM 등)
           </span>
         </div>
         {errors.contact && (

--- a/src/containers/photographer/mypage/profile/edit/edit.css.ts
+++ b/src/containers/photographer/mypage/profile/edit/edit.css.ts
@@ -108,4 +108,23 @@ export const editStyles = styleVariants({
     marginLeft: "auto",
     gap: 8,
   },
+  caption: [
+    texts["caption-01"],
+    sprinkles({
+      color: "text-03",
+    }),
+    {
+      display: "flex",
+      alignItems: "flex-start",
+      gap: 8,
+      lineHeight: "20px",
+    },
+  ],
+  error: [
+    texts["caption-01"],
+    sprinkles({
+      color: "pink",
+    }),
+    { margin: 3, display: "block" },
+  ],
 });

--- a/src/containers/photographer/mypage/profile/index.tsx
+++ b/src/containers/photographer/mypage/profile/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Photographer, PhotographerForm } from "profile-types";
+import { PhotographerForm } from "profile-types";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -17,7 +16,11 @@ import SubmitProfile from "./submit";
 const MyProfile = ({ profile }: { profile: PhotographerForm }) => {
   const router = useRouter();
   const profileSchema = z.object({
-    message: z.string(),
+    message: z.string().optional(),
+    contact: z
+      .string()
+      .min(1, { message: "연락처를 입력해 주세요." })
+      .max(100, { message: "최대 100자까지 입력 가능합니다." }),
     linkInfos: z.array(
       z.object({
         name: z.string().min(1, { message: "표시될 이름을 입력해 주세요." }),

--- a/src/services/client/photographer/mypage/profile.ts
+++ b/src/services/client/photographer/mypage/profile.ts
@@ -4,6 +4,8 @@ import apiClient from "../../core";
 export async function putProfile(form: PhotographerForm) {
   const formData = new FormData();
   const inputData = {
+    // TODO: 백엔드 프로필 수정 api 명세 확인
+    contact: form.contact,
     introductionContent: form.message,
     linkInfos: form.linkInfos.map((link) => {
       return {

--- a/src/services/client/photographer/mypage/profile.ts
+++ b/src/services/client/photographer/mypage/profile.ts
@@ -4,9 +4,8 @@ import apiClient from "../../core";
 export async function putProfile(form: PhotographerForm) {
   const formData = new FormData();
   const inputData = {
-    // TODO: 백엔드 프로필 수정 api 명세 확인
     contact: form.contact,
-    introductionContent: form.message,
+    introductionContent: (form.message !== "" && form.message) || null,
     linkInfos: form.linkInfos.map((link) => {
       return {
         linkTitle: link.name,

--- a/src/services/client/photographer/profile.ts
+++ b/src/services/client/photographer/profile.ts
@@ -2,10 +2,9 @@ import { Join } from "profile-types";
 import apiClient from "../core";
 
 export async function postProfile(form: Join) {
-  // TODO: 백엔드 join api 명세 수정 확인 필요
   const body = {
-    contact: form.contact,
     profileName: form.profileName,
+    contact: form.contact,
     termsOfServiceAgreement: form.serviceAgreement,
     privacyPolicyAgreement: form.privacyAgreement,
     marketingAgreement: form.marketingAgreement,

--- a/src/services/client/photographer/profile.ts
+++ b/src/services/client/photographer/profile.ts
@@ -2,7 +2,9 @@ import { Join } from "profile-types";
 import apiClient from "../core";
 
 export async function postProfile(form: Join) {
+  // TODO: 백엔드 join api 명세 수정 확인 필요
   const body = {
+    contact: form.contact,
     profileName: form.profileName,
     termsOfServiceAgreement: form.serviceAgreement,
     privacyPolicyAgreement: form.privacyAgreement,

--- a/src/services/server/customer/photographer.ts
+++ b/src/services/server/customer/photographer.ts
@@ -11,7 +11,7 @@ export async function getPhotographerProfile(
     profileName: data.profileName,
     bannerImg: data.bannerImageUrl || undefined,
     profileImg: data.profileImageUrl || undefined,
-    message: data.introductionContent,
+    message: data.introductionContent || "",
     linkInfos: data.linkInfos.map((link) => {
       return { name: link.linkTitle, src: link.linkUrl };
     }),

--- a/src/services/server/photographer/mypage/profile.ts
+++ b/src/services/server/photographer/mypage/profile.ts
@@ -1,11 +1,12 @@
-import { PhotographerForm, ProfileResponse } from "profile-types";
+import { PhotographerForm, PhotographerProfileResponse } from "profile-types";
 import { api } from "../../core";
 
 export async function getCurrentProfile(): Promise<PhotographerForm> {
   const { data } = await api
     .get("photographer/profile")
-    .json<{ data: ProfileResponse }>();
+    .json<{ data: PhotographerProfileResponse }>();
   return {
+    contact: data.contact,
     bannerImg:
       data.bannerImageUrl !== null ? { url: data.bannerImageUrl } : undefined,
     profileImg:

--- a/src/services/server/photographer/mypage/profile.ts
+++ b/src/services/server/photographer/mypage/profile.ts
@@ -12,7 +12,7 @@ export async function getCurrentProfile(): Promise<PhotographerForm> {
     profileImg:
       data.profileImageUrl !== null ? { url: data.profileImageUrl } : undefined,
     profileName: data.profileName,
-    message: data.introductionContent,
+    message: data.introductionContent || "",
     linkInfos: data.linkInfos.map((link) => {
       return { name: link.linkTitle, src: link.linkUrl };
     }),

--- a/src/types/profile-types.d.ts
+++ b/src/types/profile-types.d.ts
@@ -13,7 +13,7 @@ declare module "profile-types" {
     bannerImageUrl: string | null;
     profileImageUrl: string | null;
     profileName: string;
-    introductionContent: string;
+    introductionContent: string | null;
     linkInfos: { linkTitle: string; linkUrl: string }[];
   }
 

--- a/src/types/profile-types.d.ts
+++ b/src/types/profile-types.d.ts
@@ -16,6 +16,12 @@ declare module "profile-types" {
     introductionContent: string;
     linkInfos: { linkTitle: string; linkUrl: string }[];
   }
+
+  // TODO: 백엔드 api 명세 확인 필요
+  interface PhotographerProfileResponse extends ProfileResponse {
+    contact: string;
+  }
+
   interface Photographer {
     bannerImg?: string;
     profileImg?: string;
@@ -27,9 +33,11 @@ declare module "profile-types" {
   interface PhotographerForm extends Photographer {
     bannerImg?: FormImage;
     profileImg?: FormImage;
+    contact: string;
   }
 
   interface Join {
+    contact: string;
     profileName: string;
     serviceAgreement: boolean;
     privacyAgreement: boolean;


### PR DESCRIPTION
## 체크리스트
- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 사진작가측 연락처 등록 / 관리 기능 추가
사진작가 회원가입, 사진작가 프로필 조회 및 수정(내 프로필 관리 페이지) 기능에서 반영

## 고민한 사항
* api에서 연락처가 갖는 필드명을 아직 몰라서 일단 임의로 작성하고, api 연결 위치마다 주석으로 표시한 상태입니다! 백엔드쪽 개발이 완료된 이후에 문서 업데이트를 확인하고 수정할 수도 있고, 혹시 지금 필드명이 정해질 수 있다면 알려주면 바로 맞추겠습니다!
* 작업하다 보니 의뢰자측 신청서 상세 조회시에도 신청서가 수락된 상태라면 작가 연락처를 함께 띄워 주는 게 어떨까 생각이 들었습니다…! 아까 이 부분에 대해서는 논의를 못한 것 같은데, 괜찮은지 의견 부탁드립니당 (추가하게 된다면 이번 티켓은 아니고, `의뢰자측 신청서 상세 조회시 작가 프로필 페이지 링크 추가`와 같은 티켓에서 작업할 것 같습니다!)

## 리뷰 요청사항
* 연락처는 자유 형식으로 서술하는 걸 의도했다 보니 조금 넉넉하게 최대 100자로 검증 조건 설정했고 안내 문구 및 반영된 UI는 스크린샷으로 첨부했습니다! 관련해서 피드백 사항 남겨 주면 반영하겠습니다 👍
* 고민한 사항에 기능 명세 관련한 내용이 있어서, 관련해서 의견 부탁드려요 🙇

## 스크린샷
<img width="1462" alt="스크린샷 2024-10-09 오후 4 52 54" src="https://github.com/user-attachments/assets/6fdfad80-28db-4741-b372-d4c30a0626bc">
<img width="1458" alt="스크린샷 2024-10-09 오후 5 04 29" src="https://github.com/user-attachments/assets/ff19c0eb-a38d-46d9-bc3f-0e9e0b862f1a">

