### PR TITLE
[FU-250] leave service

### DIFF
--- a/src/app/auth/role/route.ts
+++ b/src/app/auth/role/route.ts
@@ -1,4 +1,4 @@
-import { setUserRole } from "@/services/server/core/auth";
+import { deleteTokens, setUserRole } from "@/services/server/core/auth";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
@@ -19,5 +19,10 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     return NextResponse.json({}, { status: 400 });
   }
+  return NextResponse.json({}, { status: 200 });
+}
+
+export async function DELETE() {
+  deleteTokens();
   return NextResponse.json({}, { status: 200 });
 }

--- a/src/components/buttons/buttons.css.ts
+++ b/src/components/buttons/buttons.css.ts
@@ -157,6 +157,16 @@ const buttonStyles = styleVariants({
       border: "none",
     },
   ],
+  danger: [
+    baseButton,
+    sprinkles({
+      color: "white",
+    }),
+    {
+      border: "none",
+      backgroundColor: "#E4473D",
+    },
+  ],
   line: [
     baseButton,
     sprinkles({

--- a/src/components/buttons/common-buttons.tsx
+++ b/src/components/buttons/common-buttons.tsx
@@ -18,7 +18,7 @@ interface ButtonProps
 
 interface ButtonOptions {
   size: "xs" | "sm" | "md" | "lg";
-  styleType: "primary" | "secondary" | "line";
+  styleType: "primary" | "secondary" | "line" | "danger";
   link?: string;
 }
 

--- a/src/components/inputs/common-input.tsx
+++ b/src/components/inputs/common-input.tsx
@@ -1,4 +1,9 @@
-import { CSSProperties, DetailedHTMLProps, InputHTMLAttributes } from "react";
+import {
+  CSSProperties,
+  DetailedHTMLProps,
+  InputHTMLAttributes,
+  TextareaHTMLAttributes,
+} from "react";
 import InputStyles from "./input.css";
 
 interface CommonInputProps
@@ -10,7 +15,20 @@ interface CommonInputProps
   inputSize?: "sm" | "md";
   placeholder?: string;
   disabled?: boolean;
-  multiline?: boolean;
+  multiline: false;
+  container?: CSSProperties;
+}
+
+interface CommonTextAreaProps
+  extends DetailedHTMLProps<
+    TextareaHTMLAttributes<HTMLTextAreaElement>,
+    HTMLTextAreaElement
+  > {
+  title?: string;
+  inputSize?: "sm" | "md";
+  placeholder?: string;
+  disabled?: boolean;
+  multiline: true;
   container?: CSSProperties;
 }
 
@@ -22,7 +40,7 @@ const CommonInput = ({
   container,
   inputSize = "sm",
   ...props
-}: CommonInputProps) => {
+}: CommonInputProps | CommonTextAreaProps) => {
   return (
     <div className={InputStyles.container} style={container}>
       {title && <span className={InputStyles.title}>{title}</span>}
@@ -37,13 +55,14 @@ const CommonInput = ({
               disabled ? InputStyles.disabledInput : InputStyles.multilineInput
             }
             placeholder={placeholder}
+            {...(props as CommonTextAreaProps)}
           />
         ) : (
           <input
             className={disabled ? InputStyles.disabledInput : InputStyles.input}
             placeholder={placeholder}
             disabled={disabled}
-            {...props}
+            {...(props as CommonInputProps)}
           />
         )}
       </div>

--- a/src/components/inputs/input.css.ts
+++ b/src/components/inputs/input.css.ts
@@ -211,7 +211,7 @@ const InputStyles = styleVariants({
       marginRight: "auto",
     },
   ],
-  multilineInput: [baseInput],
+  multilineInput: [baseInput, { resize: "vertical" }],
 });
 
 export default InputStyles;

--- a/src/containers/customer/products/products.css.ts
+++ b/src/containers/customer/products/products.css.ts
@@ -125,9 +125,11 @@ export const infoStyles = styleVariants({
 export const modalStyles = styleVariants({
   content: {
     borderRadius: 16,
+    padding: "0px 16px 16px 16px",
   },
   header: {
-    paddingBottom: 0,
+    padding: 30,
+    justifyContent: "center",
     alignItems: "flex-start",
   },
   body: {
@@ -150,6 +152,11 @@ export const modalStyles = styleVariants({
       color: "text-02",
     }),
   ],
+  close: {
+    position: "absolute",
+    top: 25,
+    right: 10,
+  },
 });
 
 export const indicatorStyle = style({

--- a/src/containers/customer/reservation/details/cancel-modal.tsx
+++ b/src/containers/customer/reservation/details/cancel-modal.tsx
@@ -42,6 +42,7 @@ const CancelModal = ({
       <CommonInput
         placeholder="취소 사유를 입력해 주세요."
         value={cancellationReason}
+        multiline={false}
         onChange={(e) => setCancellationReason(e.currentTarget.value)}
       />
       <CustomButton

--- a/src/containers/photographer/mypage/profile/edit/edit.css.ts
+++ b/src/containers/photographer/mypage/profile/edit/edit.css.ts
@@ -115,6 +115,9 @@ export const leaveStyles = styleVariants({
     marginTop: 60,
     marginLeft: "auto",
   },
+  wrapper: {
+    width: "100%",
+  },
   button: [
     texts["headline-03"],
     sprinkles({ color: "text-02" }),
@@ -130,4 +133,15 @@ export const leaveStyles = styleVariants({
     { minWidth: "fit-content" },
   ],
   message: [texts["headline-03"], sprinkles({ color: "text-point" })],
+  list: [
+    texts["body-01"],
+    sprinkles({ backgroundColor: "bg-lightgrey", color: "text-02" }),
+    { borderRadius: 16, padding: 10, paddingInlineStart: 30 },
+  ],
+  reasonWrapper: {
+    display: "flex",
+    flexDirection: "column",
+    padding: "10px 0px",
+    gap: 8,
+  },
 });

--- a/src/containers/photographer/mypage/profile/edit/edit.css.ts
+++ b/src/containers/photographer/mypage/profile/edit/edit.css.ts
@@ -52,7 +52,7 @@ export const editStyles = styleVariants({
     display: "flex",
     flexDirection: "column",
     minWidth: 380,
-    paddingBottom: 60,
+    paddingBottom: 10,
 
     "@media": {
       [breakpoints.mobile]: {
@@ -108,4 +108,20 @@ export const editStyles = styleVariants({
     marginLeft: "auto",
     gap: 8,
   },
+});
+
+export const leaveStyles = styleVariants({
+  container: {
+    marginTop: 60,
+    marginLeft: "auto",
+  },
+  button: [
+    texts["headline-03"],
+    sprinkles({ color: "pink" }),
+    {
+      background: "none",
+      border: "none",
+      textDecoration: "underline",
+    },
+  ],
 });

--- a/src/containers/photographer/mypage/profile/edit/edit.css.ts
+++ b/src/containers/photographer/mypage/profile/edit/edit.css.ts
@@ -117,11 +117,17 @@ export const leaveStyles = styleVariants({
   },
   button: [
     texts["headline-03"],
-    sprinkles({ color: "pink" }),
+    sprinkles({ color: "text-02" }),
     {
       background: "none",
       border: "none",
       textDecoration: "underline",
     },
   ],
+  title: [
+    texts["headline-02"],
+    sprinkles({ color: "text-02" }),
+    { minWidth: "fit-content" },
+  ],
+  message: [texts["headline-03"], sprinkles({ color: "text-point" })],
 });

--- a/src/containers/photographer/mypage/profile/edit/index.tsx
+++ b/src/containers/photographer/mypage/profile/edit/index.tsx
@@ -3,6 +3,7 @@ import Banner from "./banner";
 import BasicInfo from "./basic-info";
 import { editStyles } from "./edit.css";
 import Links from "./links";
+import Leave from "./leave";
 
 const ProfileEdit = () => {
   return (
@@ -12,6 +13,7 @@ const ProfileEdit = () => {
         <Banner />
       </div>
       <Links />
+      <Leave />
     </div>
   );
 };

--- a/src/containers/photographer/mypage/profile/edit/leave-modal.tsx
+++ b/src/containers/photographer/mypage/profile/edit/leave-modal.tsx
@@ -6,8 +6,18 @@ import { CustomButton } from "@/components/buttons/common-buttons";
 import popToast from "@/components/common/toast";
 import { responseHandler } from "@/services/common/error";
 import CommonInput from "@/components/inputs/common-input";
+import CheckBox from "@/components/inputs/checkbox";
 import { leaveService } from "@/services/client/photographer/mypage/profile";
 import { leaveStyles } from "./edit.css";
+
+const EXAMPLE_REASONS = [
+  { value: "고객이 불편해해요" },
+  { value: "이제 촬영을 진행하지 않아요" },
+  { value: "서비스 퀄리티가 낮아요" },
+  { value: "신청이 잘 들어오지 않아요" },
+  { value: "이용이 불편해요" },
+  { value: "기타" },
+];
 
 const LeaveModal = ({
   close,
@@ -17,11 +27,12 @@ const LeaveModal = ({
   close: () => void;
 }) => {
   const router = useRouter();
+  const [selectedReason, setSelectedReason] = useState("");
   const [reason, setReason] = useState("");
 
   async function handleLeave() {
     await responseHandler(
-      leaveService(reason),
+      leaveService(selectedReason === "기타" ? reason : selectedReason),
       () => {
         close();
         popToast(
@@ -31,36 +42,83 @@ const LeaveModal = ({
         router.push("/login/photographer");
       },
       () => {
-        close();
         popToast("다시 시도해주세요.", "탈퇴에 실패했습니다.", true);
-        router.refresh();
       },
     );
+  }
+
+  function handleSelectReason(newReason: string) {
+    if (selectedReason === newReason) {
+      setSelectedReason("");
+    } else {
+      setSelectedReason(newReason);
+    }
   }
 
   return (
     <Modal
       centered
+      size="lg"
       opened={opened}
       onClose={close}
+      title="정말로 프리비를 탈퇴하시겠어요?"
       classNames={{ ...modalStyles }}
     >
-      <div className={leaveStyles.title}>정말로 프리비를 탈퇴하시겠어요?</div>
-      <div className={leaveStyles.message}>
-        서비스를 탈퇴하실 경우, 기존에 등록했던 상품과 진행했던 신청 일정을 다시
-        확인할 수 없어요.
+      <div className={leaveStyles.wrapper}>
+        <div className={leaveStyles.message}>
+          탈퇴하시기 전, 다음 내용을 꼭 확인해주세요.
+        </div>
+        <ul className={leaveStyles.list}>
+          <li>
+            예약 진행 중인 촬영이 있다면 탈퇴가 불가능합니다. 모든 촬영을 완료한
+            뒤 탈퇴해주세요.
+          </li>
+          <li>
+            회원 탈퇴 이후 기존 상품과 지난 예약건에 대한 복구가 불가능합니다.
+          </li>
+          <li>회원 탈퇴 이후 서비스에서 발급된 링크를 사용하실 수 없습니다.</li>
+          <li>
+            탈퇴 이후 작가님의 정보는 프리비 개인정보처리방침에 따라 관리됩니다.
+          </li>
+          <li>
+            탈퇴 이후에도 작가님과 촬영을 진행한 고객은 촬영 내역을 확인할 수
+            있습니다. (단, 작가님께서 등록하신 연락처는 제공되지 않습니다.)
+          </li>
+        </ul>
+        <div className={leaveStyles.message}>
+          탈퇴하시는 이유를 알려주시면 더 나은 서비스를 만들기 위해 노력할게요.
+        </div>
+        <div className={leaveStyles.reasonWrapper}>
+          {EXAMPLE_REASONS.map((item) => {
+            return (
+              <CheckBox
+                key={item.value}
+                title={item.value}
+                onPress={() => {
+                  handleSelectReason(item.value);
+                }}
+                checked={selectedReason === item.value}
+              />
+            );
+          })}
+        </div>
+        {selectedReason === "기타" && (
+          <CommonInput
+            placeholder="탈퇴 사유를 작성해주세요."
+            value={reason}
+            onChange={(e) => setReason(e.currentTarget.value)}
+            multiline
+          />
+        )}
       </div>
-      <CommonInput
-        placeholder="탈퇴 사유를 작성해주세요."
-        value={reason}
-        onChange={(e) => setReason(e.currentTarget.value)}
-        multiline
-      />
+
       <CustomButton
-        size="sm"
+        size="md"
         styleType="danger"
         title="탈퇴하기"
-        disabled={reason === ""}
+        disabled={
+          (reason === "" && selectedReason === "기타") || selectedReason === ""
+        }
         onClick={handleLeave}
       />
     </Modal>

--- a/src/containers/photographer/mypage/profile/edit/leave-modal.tsx
+++ b/src/containers/photographer/mypage/profile/edit/leave-modal.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Modal } from "@mantine/core";
+import { modalStyles } from "@/containers/customer/products/products.css";
+import { CustomButton } from "@/components/buttons/common-buttons";
+import popToast from "@/components/common/toast";
+import { responseHandler } from "@/services/common/error";
+import CommonInput from "@/components/inputs/common-input";
+import { leaveService } from "@/services/client/photographer/mypage/profile";
+import { leaveStyles } from "./edit.css";
+
+const LeaveModal = ({
+  close,
+  opened,
+}: {
+  opened: boolean;
+  close: () => void;
+}) => {
+  const router = useRouter();
+  const [reason, setReason] = useState("");
+
+  async function handleLeave() {
+    await responseHandler(
+      leaveService(reason),
+      () => {
+        close();
+        popToast(
+          "그동안 프리비를 이용해주셔서 감사합니다.",
+          "탈퇴가 완료되었습니다.",
+        );
+        router.push("/login/photographer");
+      },
+      () => {
+        close();
+        popToast("다시 시도해주세요.", "탈퇴에 실패했습니다.", true);
+        router.refresh();
+      },
+    );
+  }
+
+  return (
+    <Modal
+      centered
+      opened={opened}
+      onClose={close}
+      classNames={{ ...modalStyles }}
+    >
+      <div className={leaveStyles.title}>정말로 프리비를 탈퇴하시겠어요?</div>
+      <div className={leaveStyles.message}>
+        서비스를 탈퇴하실 경우, 기존에 등록했던 상품과 진행했던 신청 일정을 다시
+        확인할 수 없어요.
+      </div>
+      <CommonInput
+        placeholder="탈퇴 사유를 작성해주세요."
+        value={reason}
+        onChange={(e) => setReason(e.currentTarget.value)}
+        multiline
+      />
+      <CustomButton
+        size="sm"
+        styleType="danger"
+        title="탈퇴하기"
+        disabled={reason === ""}
+        onClick={handleLeave}
+      />
+    </Modal>
+  );
+};
+
+export default LeaveModal;

--- a/src/containers/photographer/mypage/profile/edit/leave.tsx
+++ b/src/containers/photographer/mypage/profile/edit/leave.tsx
@@ -1,9 +1,14 @@
+import { useDisclosure } from "@mantine/hooks";
 import { leaveStyles } from "./edit.css";
+import LeaveModal from "./leave-modal";
 
 const Leave = () => {
+  const [opened, { open, close }] = useDisclosure(false);
+
   return (
     <div className={leaveStyles.container}>
-      <button className={leaveStyles.button} type="button">
+      <LeaveModal opened={opened} close={close} />
+      <button onClick={open} className={leaveStyles.button} type="button">
         서비스 탈퇴하기
       </button>
     </div>

--- a/src/containers/photographer/mypage/profile/edit/leave.tsx
+++ b/src/containers/photographer/mypage/profile/edit/leave.tsx
@@ -1,0 +1,12 @@
+import { leaveStyles } from "./edit.css";
+
+const Leave = () => {
+  return (
+    <div className={leaveStyles.container}>
+      <button className={leaveStyles.button} type="button">
+        서비스 탈퇴하기
+      </button>
+    </div>
+  );
+};
+export default Leave;

--- a/src/services/client/photographer/mypage/profile.ts
+++ b/src/services/client/photographer/mypage/profile.ts
@@ -37,6 +37,18 @@ export async function putProfile(form: PhotographerForm) {
   });
 }
 
+async function deleteCookiesAfterLeave(retryCount: number) {
+  const MAX_RETRY_COUNT = 5;
+  try {
+    await fetch("/auth/role", { method: "DELETE" });
+  } catch {
+    if (MAX_RETRY_COUNT > retryCount) {
+      deleteCookiesAfterLeave(retryCount + 1);
+    }
+  }
+}
+
 export async function leaveService(reason: string) {
   await apiClient.post("unlink", { json: { reason } });
+  await deleteCookiesAfterLeave(0);
 }

--- a/src/services/client/photographer/mypage/profile.ts
+++ b/src/services/client/photographer/mypage/profile.ts
@@ -36,3 +36,7 @@ export async function putProfile(form: PhotographerForm) {
     body: formData,
   });
 }
+
+export async function leaveService(reason: string) {
+  await apiClient.post("unlink", { json: { reason } });
+}


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 서비스 탈퇴 기능

## 고민한 사항
* 탈퇴 후 토큰 관리
탈퇴한 이후에는 로그인 페이지로 이동하게 하는 게 적합하다고 생각했는데, 이 경우 클라이언트쪽에서 저장한 토큰과 role도 삭제가 필요해서 어떻게 로직을 구성할지 고민이 있었습니다. 탈퇴 api 성공 이후 로그아웃 api를 추가로 호출하는 방안도 떠올랐으나, 이때 탈퇴 성공 - 로그아웃 실패 케이스가 생기면 재시도시 무조건 탈퇴 api까지 재시도되면서 정상적으로 동작이 불가능할 것 같다는 점이 우려되었습니다. 탈퇴 api 로직 내에서 토큰을 삭제하는 쪽으로 논의한 이후 (함께 고민해 줘서 감사합니다 🙇) 프론트엔드에서 저장하고 있는 토큰과 role만 제거하기 위해 route handler에서 해당 역할만 처리하는 메서드를 추가했고, 자체적으로 retry 로직을 달아 놓았습니다.

## 리뷰 요청사항
* 시급도: `보통`
프로필 관리 페이지에서 접근할 수 있도록 한 상태입니다! 탈퇴 기능 관련한 UI/UX 피드백 있다면 반영하겠습니다.
* `src/services/client/photographer/mypage/profile.ts`: 탈퇴 api 요청 및 토큰 삭제 로직 구현

## 스크린샷
![FU-250](https://github.com/user-attachments/assets/9fd6ae4c-2a72-4d23-90db-fca7a8c78ba1)


[FU-250]: https://for-u.atlassian.net/browse/FU-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ