### PR TITLE
[FU-291] shooting place

### DIFF
--- a/src/components/common/common.css.ts
+++ b/src/components/common/common.css.ts
@@ -2,6 +2,19 @@ import sprinkles from "@/styles/sprinkles.css";
 import { texts } from "@/styles/text.css";
 import { style, styleVariants } from "@vanilla-extract/css";
 
+export const captionStyle = style([
+  texts["caption-01"],
+  sprinkles({
+    color: "text-03",
+  }),
+  {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: 8,
+    lineHeight: "20px",
+  },
+]);
+
 export const bottomSheetStyles = styleVariants({
   container: {
     display: "flex",

--- a/src/components/common/info-caption.tsx
+++ b/src/components/common/info-caption.tsx
@@ -1,9 +1,16 @@
+import { CSSProperties } from "react";
 import Image from "next/image";
 import { captionStyle } from "./common.css";
 
-const InfoCaption = ({ information }: { information: string }) => {
+const InfoCaption = ({
+  information,
+  container,
+}: {
+  information: string;
+  container?: CSSProperties;
+}) => {
   return (
-    <div className={captionStyle}>
+    <div className={captionStyle} style={{ ...container }}>
       <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
       <span>{information}</span>
     </div>

--- a/src/components/common/info-caption.tsx
+++ b/src/components/common/info-caption.tsx
@@ -1,0 +1,13 @@
+import Image from "next/image";
+import { captionStyle } from "./common.css";
+
+const InfoCaption = ({ information }: { information: string }) => {
+  return (
+    <div className={captionStyle}>
+      <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
+      <span>{information}</span>
+    </div>
+  );
+};
+
+export default InfoCaption;

--- a/src/containers/customer/products/info.tsx
+++ b/src/containers/customer/products/info.tsx
@@ -17,6 +17,8 @@ const ProductInfo = ({
   items,
   options,
   subtitle,
+  basicPlace,
+  allowPreferredPlace,
   title,
   basicPrice,
   images,
@@ -79,6 +81,14 @@ const ProductInfo = ({
       </div>
       <div className={infoStyles.wrapper}>
         <div className={infoStyles.itemsWrapper}>
+          <ProductItem
+            key="basic-place"
+            title="촬영 장소"
+            content={basicPlace}
+            description={
+              allowPreferredPlace ? "신청 시 희망 장소 요청 가능" : ""
+            }
+          />
           {items.map((item, index) => {
             return <ProductItem key={index} {...item} />;
           })}

--- a/src/containers/customer/reservation/details/info.tsx
+++ b/src/containers/customer/reservation/details/info.tsx
@@ -8,6 +8,7 @@ import ShootingInfos from "./infos/shooting";
 
 const Info = ({
   basicPrice,
+  basicPlace,
   shootingDate,
   options,
   preferredDates,
@@ -19,7 +20,7 @@ const Info = ({
 }: Omit<CustomerDetails, "currentStatus" | "productTitle">) => {
   return (
     <div className={detailStyles.body}>
-      <ProductInfos productInfo={productInfo} />
+      <ProductInfos basicPlace={basicPlace} productInfo={productInfo} />
       <RequestInfos
         requestMemo={requestMemo}
         preferredDates={preferredDates}

--- a/src/containers/customer/reservation/details/info.tsx
+++ b/src/containers/customer/reservation/details/info.tsx
@@ -2,9 +2,9 @@ import { CustomerDetails } from "reservation-types";
 import { detailStyles } from "./detail.css";
 import ProductInfos from "./infos/product";
 import OptionInfos from "./infos/option";
-import ScheduleInfos from "./infos/schedule";
 import RequestInfos from "./infos/request";
 import Confirm from "./infos/confirm";
+import ShootingInfos from "./infos/shooting";
 
 const Info = ({
   basicPrice,
@@ -14,15 +14,21 @@ const Info = ({
   productInfo,
   requestMemo,
   totalPrice,
+  preferredPlace,
+  shootingPlace,
 }: Omit<CustomerDetails, "currentStatus" | "productTitle">) => {
   return (
     <div className={detailStyles.body}>
       <ProductInfos productInfo={productInfo} />
-      <ScheduleInfos
+      <RequestInfos
+        requestMemo={requestMemo}
         preferredDates={preferredDates}
-        shootingDate={shootingDate}
+        preferredPlace={preferredPlace}
       />
-      <RequestInfos requestMemo={requestMemo} />
+      <ShootingInfos
+        shootingDate={shootingDate}
+        shootingPlace={shootingPlace}
+      />
       <OptionInfos options={options} basicPrice={basicPrice} />
       <Confirm totalPrice={totalPrice} />
     </div>

--- a/src/containers/customer/reservation/details/infos/infos.css.ts
+++ b/src/containers/customer/reservation/details/infos/infos.css.ts
@@ -27,6 +27,15 @@ export const infoStyles = styleVariants({
     flexDirection: "column",
     gap: 10,
   },
+  requestWrapper: [
+    sprinkles({ borderColor: "stroke-grey" }),
+    {
+      borderBottomWidth: 1,
+      borderBottomStyle: "solid",
+      paddingBottom: 16,
+      marginBottom: 16,
+    },
+  ],
   item: {
     display: "flex",
     alignItems: "top",

--- a/src/containers/customer/reservation/details/infos/product.tsx
+++ b/src/containers/customer/reservation/details/infos/product.tsx
@@ -18,11 +18,13 @@ const ProductItem = ({
 
 const ProductInfos = ({
   productInfo,
-}: Pick<CustomerDetails, "productInfo">) => {
+  basicPlace,
+}: Pick<CustomerDetails, "productInfo" | "basicPlace">) => {
   return (
     <div className={infoStyles.container}>
       <span className={infoStyles.title}>촬영 정보</span>
       <div className={infoStyles.wrapper}>
+        <ProductItem key="basicPlace" title="촬영 장소" content={basicPlace} />
         {productInfo.map((info) => (
           <ProductItem key={info.title} {...info} />
         ))}

--- a/src/containers/customer/reservation/details/infos/request.tsx
+++ b/src/containers/customer/reservation/details/infos/request.tsx
@@ -1,11 +1,63 @@
-import { CustomerDetails } from "reservation-types";
+import { CustomerDetails, ReservationDate } from "reservation-types";
+import { formatDate, formatTimeString } from "@/utils/date";
 import { infoStyles } from "./infos.css";
+
+const ScheduleItem = ({
+  date,
+  endTime,
+  startTime,
+  title,
+}: ReservationDate & { title: string }) => {
+  const dateValue = new Date(date);
+  return (
+    <div className={infoStyles.item}>
+      <span className={infoStyles.name}>{title}</span>
+      <div className={infoStyles.schedule}>
+        <span className={infoStyles.content}>
+          {formatDate(date)} (
+          {dateValue.toLocaleString("KR", { weekday: "short" })})
+        </span>
+        <span className={infoStyles.content}>
+          {formatTimeString(startTime)} ~
+        </span>
+        <span className={infoStyles.content}>{formatTimeString(endTime)}</span>
+      </div>
+    </div>
+  );
+};
 
 const RequestInfos = ({
   requestMemo,
-}: Pick<CustomerDetails, "requestMemo">) => {
+  preferredDates,
+  preferredPlace,
+}: Pick<
+  CustomerDetails,
+  "requestMemo" | "preferredDates" | "preferredPlace"
+>) => {
   return (
     <div className={infoStyles.container}>
+      {preferredDates.length > 0 && (
+        <div className={infoStyles.requestWrapper}>
+          <span className={infoStyles.title}>희망 일정</span>
+          <div className={infoStyles.wrapper}>
+            {preferredDates.map((info, index) => (
+              <ScheduleItem
+                key={info.date}
+                title={`${index + 1}차 희망`}
+                {...info}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+      {preferredPlace && (
+        <div className={infoStyles.requestWrapper}>
+          <span className={infoStyles.title}>희망 장소</span>
+          <div className={infoStyles.wrapper}>
+            <span className={infoStyles.article}>{preferredPlace}</span>
+          </div>
+        </div>
+      )}
       <span className={infoStyles.title}>요청 메모</span>
       <div className={infoStyles.wrapper}>
         <span className={infoStyles.article}>{requestMemo}</span>

--- a/src/containers/customer/reservation/details/infos/shooting.tsx
+++ b/src/containers/customer/reservation/details/infos/shooting.tsx
@@ -1,0 +1,64 @@
+import { CustomerDetails, ReservationDate } from "reservation-types";
+import { formatDate, formatTimeString } from "@/utils/date";
+import { infoStyles } from "./infos.css";
+
+const ScheduleItem = ({
+  date,
+  title,
+  dateValue,
+}: {
+  title: string;
+  date?: ReservationDate;
+  dateValue?: Date;
+}) => {
+  return (
+    <div className={infoStyles.item}>
+      <span className={infoStyles.name}>{title}</span>
+      {date ? (
+        <div className={infoStyles.schedule}>
+          <span className={infoStyles.content}>
+            {formatDate(date.date)} (
+            {dateValue && dateValue.toLocaleString("KR", { weekday: "short" })})
+          </span>
+          <span className={infoStyles.content}>
+            {formatTimeString(date.startTime)} ~
+          </span>
+          <span className={infoStyles.content}>
+            {formatTimeString(date.endTime)}
+          </span>
+        </div>
+      ) : (
+        <span className={infoStyles.content}>아직 확정되지 않았습니다.</span>
+      )}
+    </div>
+  );
+};
+
+const ShootingInfos = ({
+  shootingDate,
+  shootingPlace,
+}: Pick<CustomerDetails, "shootingDate" | "shootingPlace">) => {
+  return (
+    <div className={infoStyles.container}>
+      <span className={infoStyles.title}>확정 정보</span>
+      <div className={infoStyles.wrapper}>
+        <ScheduleItem
+          key="shootingDate"
+          title="확정 일정"
+          date={undefined}
+          dateValue={shootingDate ? new Date(shootingDate.date) : undefined}
+        />
+      </div>
+      <div className={infoStyles.wrapper}>
+        <div className={infoStyles.item}>
+          <span className={infoStyles.name}>확정 장소</span>
+          <span className={infoStyles.content}>
+            {shootingPlace || "아직 확정되지 않았습니다."}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShootingInfos;

--- a/src/containers/customer/reservation/reservation-form-provider.tsx
+++ b/src/containers/customer/reservation/reservation-form-provider.tsx
@@ -24,6 +24,7 @@ const ReservationFormProvider = ({
     instagram: "",
     schedules: [],
     options: [],
+    preferredPlace: "",
     referenceImages: [],
     memo: "",
     photographerAgreement: false,
@@ -60,6 +61,7 @@ const ReservationFormProvider = ({
     schedules: z.array(scheduleListSchema).optional(),
     options: z.array(selectedOptionSchema).optional(),
     memo: z.string().max(300, { message: "최대 300자까지 입력 가능합니다." }),
+    preferredPlace: z.string(),
     referenceImages: z
       .array(
         z.object({

--- a/src/containers/customer/reservation/submit-form.tsx
+++ b/src/containers/customer/reservation/submit-form.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
-import { Item, Option, reservation } from "product-types";
+import { Product, reservation } from "product-types";
 import { BottomButton } from "@/components/buttons/common-buttons";
 import CustomerInfoForm from "@/containers/customer/reservation/submit/parts/customer-info-form";
 import ProductInfoForm from "@/containers/customer/reservation/submit/parts/product-info-form";
@@ -20,14 +20,16 @@ const SubmitForm = ({
   items,
   options,
   basicPrice,
+  basicPlace,
+  allowPreferredPlace,
 }: Pick<
   reservation.FormType,
   "contact" | "instagram" | "name" | "productId" | "profileName"
-> & {
-  options: Option[];
-  items: Item[];
-  basicPrice: number;
-}) => {
+> &
+  Pick<
+    Product,
+    "basicPlace" | "allowPreferredPlace" | "items" | "options" | "basicPrice"
+  >) => {
   const {
     setValue,
     watch,
@@ -66,7 +68,12 @@ const SubmitForm = ({
       }}
     >
       <CustomerInfoForm />
-      <ProductInfoForm items={items} basicPrice={basicPrice} />
+      <ProductInfoForm
+        items={items}
+        basicPrice={basicPrice}
+        allowPreferredPlace={allowPreferredPlace}
+        basicPlace={basicPlace}
+      />
       <RequestForm />
       <SelectOptionForm options={options} />
       <TotalPriceForm basicPrice={basicPrice} />

--- a/src/containers/customer/reservation/submit/parts/product-info-form.tsx
+++ b/src/containers/customer/reservation/submit/parts/product-info-form.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
-import { Item, reservation } from "product-types";
+import { Product, reservation } from "product-types";
 import { useDisclosure } from "@mantine/hooks";
 import TextInput from "@/components/inputs/text-input";
 import ScheduleInput from "@/components/inputs/schedule-input";
 import { CustomButton } from "@/components/buttons/common-buttons";
+import InfoCaption from "@/components/common/info-caption";
 import PartLayout from "../part-layout";
 import submitStyles from "../submit.css";
 import ScheduleModal from "../schedule-modal";
@@ -14,10 +15,12 @@ const MAX_SCHEDULE_SELECT = 3;
 const ProductInfoForm = ({
   items,
   basicPrice,
-}: {
-  items: Item[];
-  basicPrice: number;
-}) => {
+  basicPlace,
+  allowPreferredPlace,
+}: Pick<
+  Product,
+  "items" | "basicPrice" | "basicPlace" | "allowPreferredPlace"
+>) => {
   const [editIndex, setEditIndex] = useState<number>();
 
   function handleFinishEditSchedule() {
@@ -57,6 +60,7 @@ const ProductInfoForm = ({
     <PartLayout title="촬영 정보">
       <ScheduleModal close={close} opened={opened} targetIndex={editIndex} />
       <TextInput title="기본 가격" disabled value={basicPrice} />
+      <TextInput title="촬영 장소" disabled value={basicPlace} />
       {items.map((item, index) => {
         return (
           <TextInput
@@ -67,6 +71,17 @@ const ProductInfoForm = ({
           />
         );
       })}
+      {allowPreferredPlace && (
+        <div style={{ marginBottom: 20 }}>
+          <TextInput<reservation.FormType>
+            title="희망 장소"
+            placeholder="장소를 입력해주세요."
+            formField="preferredPlace"
+            container={{ marginBottom: 8 }}
+          />
+          <InfoCaption information="등록되어 있는 촬영 장소 외에 더 구체적으로 원하는 장소가 있다면 작성해주세요. 작가님과의 협의 후에 확정됩니다." />
+        </div>
+      )}
       <span className={submitStyles.itemTitle}>촬영 일정</span>
       {schedules.map((field, index) => {
         return (

--- a/src/containers/photographer/join/join.css.ts
+++ b/src/containers/photographer/join/join.css.ts
@@ -81,18 +81,6 @@ export const profileStyles = styleVariants({
     }),
     { margin: 3, display: "block", position: "static" },
   ],
-  caption: [
-    texts["caption-01"],
-    sprinkles({
-      color: "text-03",
-    }),
-    {
-      display: "flex",
-      alignItems: "flex-start",
-      gap: 8,
-      lineHeight: "20px",
-    },
-  ],
 });
 
 const baseWrapper = style([

--- a/src/containers/photographer/join/profile.tsx
+++ b/src/containers/photographer/join/profile.tsx
@@ -1,6 +1,6 @@
-import Image from "next/image";
 import { useFormContext } from "react-hook-form";
 import { Join } from "profile-types";
+import InfoCaption from "@/components/common/info-caption";
 import TextInput from "@/components/inputs/text-input";
 import { profileStyles } from "./join.css";
 
@@ -17,12 +17,7 @@ const Profile = () => {
         formField="profileName"
         container={{ marginBottom: 10 }}
       />
-      <div className={profileStyles.caption}>
-        <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
-        <span>
-          설정한 아이디는 고객에게 노출되며, 설정한 이후에 변경이 불가능합니다.
-        </span>
-      </div>
+      <InfoCaption information="설정한 아이디는 고객에게 노출되며, 설정한 이후에 변경이 불가능합니다." />
       {errors.profileName && (
         <span className={profileStyles.error}>
           {errors.profileName.message}
@@ -35,13 +30,10 @@ const Profile = () => {
         multiline
         container={{ marginBottom: 10 }}
       />
-      <div className={profileStyles.caption}>
-        <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
-        <span>
-          설정한 연락처는(전화번호, 카카오톡 채팅방 링크, 인스타그램 아이디 등)
-          작가님께서 예약을 수락하신 고객에게만 전달됩니다.
-        </span>
-      </div>
+      <InfoCaption
+        information="설정한 연락처는(전화번호, 카카오톡 채팅방 링크, 인스타그램 아이디 등)
+          작가님께서 예약을 수락하신 고객에게만 전달됩니다."
+      />
       {errors.contact && (
         <span className={profileStyles.error}>{errors.contact.message}</span>
       )}

--- a/src/containers/photographer/mypage/previous/index.tsx
+++ b/src/containers/photographer/mypage/previous/index.tsx
@@ -22,7 +22,6 @@ const PreviousReservations = () => {
   }, [searchParams]);
 
   function handleSetKeyword() {
-    // TODO: 한글 검색어 테스트 필요
     setParams((prev) => {
       return { ...prev, keyword: search };
     });

--- a/src/containers/photographer/mypage/profile/edit/basic-info.tsx
+++ b/src/containers/photographer/mypage/profile/edit/basic-info.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent } from "react";
-import Image from "next/image";
 import { useFormContext } from "react-hook-form";
 import { PhotographerForm } from "profile-types";
+import InfoCaption from "@/components/common/info-caption";
 import TextInput from "@/components/inputs/text-input";
 import ProfileImage from "@/components/images/profile-image";
 import { CustomButton } from "@/components/buttons/common-buttons";
@@ -70,13 +70,10 @@ const BasicInfo = () => {
           multiline
           container={{ marginBottom: 10 }}
         />
-        <div className={editStyles.caption}>
-          <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
-          <span>
-            설정한 연락처는(전화번호, 카카오톡 채팅방 링크, 인스타그램 아이디
-            등) 작가님께서 예약을 수락하신 고객에게만 전달됩니다.
-          </span>
-        </div>
+        <InfoCaption
+          information="설정한 연락처는(전화번호, 카카오톡 채팅방 링크, 인스타그램 아이디
+            등) 작가님께서 예약을 수락하신 고객에게만 전달됩니다."
+        />
         {errors.contact && (
           <span className={editStyles.error}>{errors.contact.message}</span>
         )}

--- a/src/containers/photographer/mypage/profile/edit/edit.css.ts
+++ b/src/containers/photographer/mypage/profile/edit/edit.css.ts
@@ -108,18 +108,6 @@ export const editStyles = styleVariants({
     marginLeft: "auto",
     gap: 8,
   },
-  caption: [
-    texts["caption-01"],
-    sprinkles({
-      color: "text-03",
-    }),
-    {
-      display: "flex",
-      alignItems: "flex-start",
-      gap: 8,
-      lineHeight: "20px",
-    },
-  ],
   error: [
     texts["caption-01"],
     sprinkles({

--- a/src/containers/photographer/product/form/field/image-input.tsx
+++ b/src/containers/photographer/product/form/field/image-input.tsx
@@ -1,8 +1,8 @@
 import { Dispatch, SetStateAction, useRef, useState } from "react";
-import Image from "next/image";
 import { FormImage } from "product-types";
 import { Modal } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import InfoCaption from "@/components/common/info-caption";
 import ImageThumbnail from "@/components/images/image-thumbnail";
 import { getFormImageFromFiles } from "@/utils/image";
 import {
@@ -97,15 +97,11 @@ const ImagesInput = ({ images, setImage, disabled }: ImageInputProps) => {
         />
       </Modal>
       <span className={formStyles.subtitle}>상품 사진</span>
-
       {!disabled && (
-        <div className={formStyles.caption}>
-          <Image src="/icons/error.svg" alt="확인" height={20} width={12} />
-          <span>
-            업로드하기 전, 포트폴리오로 사용할 수 있는 사진인지 확인해주세요.
-            도용 및 무단 사용된 이미지는 삭제될 수 있습니다.
-          </span>
-        </div>
+        <InfoCaption
+          information="업로드하기 전, 포트폴리오로 사용할 수 있는 사진인지 확인해주세요.
+            도용 및 무단 사용된 이미지는 삭제될 수 있습니다."
+        />
       )}
       <div
         style={{

--- a/src/containers/photographer/product/form/field/item-field-array.tsx
+++ b/src/containers/photographer/product/form/field/item-field-array.tsx
@@ -1,6 +1,8 @@
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { ProductFormdata } from "product-types";
 import { CustomButton } from "@/components/buttons/common-buttons";
+import CheckBox from "@/components/inputs/checkbox";
+import InfoCaption from "@/components/common/info-caption";
 import ItemInput from "./item-input";
 import { formStyles, inputStyles, textInput } from "../form.css";
 
@@ -8,16 +10,25 @@ const ItemFieldArray = ({ disabled }: { disabled?: boolean }) => {
   const {
     control,
     register,
+    watch,
+    setValue,
+    getValues,
     formState: { errors },
   } = useFormContext<ProductFormdata>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: "items",
   });
+  const allowPreferredPlace = watch("allowPreferredPlace");
+
+  function handleClickCheckbox() {
+    const currentAvailability = getValues("allowPreferredPlace");
+    setValue("allowPreferredPlace", !currentAvailability);
+  }
 
   return (
     <div style={{ minWidth: "fit-content" }}>
-      <div style={{ marginBottom: 40 }}>
+      <div style={{ marginBottom: 20 }}>
         <span className={formStyles.subtitle}>기본 가격</span>
         <div className={inputStyles.content}>
           <input
@@ -36,8 +47,43 @@ const ItemFieldArray = ({ disabled }: { disabled?: boolean }) => {
           <span className={formStyles.error}>{errors.basicPrice?.message}</span>
         )}
       </div>
+      <div style={{ marginBottom: 20 }}>
+        <span className={formStyles.subtitle}>촬영 장소</span>
+        <div className={inputStyles.content}>
+          <input
+            className={textInput}
+            disabled={disabled}
+            placeholder="장소를 입력해주세요."
+            type="text"
+            {...register("basicPlace")}
+          />
+        </div>
+        {errors.basicPlace && (
+          <span className={formStyles.error}>{errors.basicPlace?.message}</span>
+        )}
+      </div>
+      {disabled ? (
+        <div style={{ marginBottom: 40 }}>
+          <CheckBox
+            checked={allowPreferredPlace}
+            onPress={() => {}}
+            title="고객이 신청할 때 희망 장소를 작성할 수 있습니다."
+          />
+        </div>
+      ) : (
+        <div style={{ marginBottom: 40 }}>
+          <CheckBox
+            checked={allowPreferredPlace}
+            onPress={handleClickCheckbox}
+            title="고객이 신청할 때 희망 장소를 작성할 수 있습니다."
+          />
+          <InfoCaption
+            container={{ marginLeft: 40 }}
+            information="촬영 장소가 협의 후 확정될 예정이라면, 위 항목을 선택해주세요."
+          />
+        </div>
+      )}
       <span className={formStyles.subtitle}>상품 구성</span>
-
       {fields.map((item, index) => {
         return (
           <ItemInput

--- a/src/containers/photographer/product/form/index.tsx
+++ b/src/containers/photographer/product/form/index.tsx
@@ -35,6 +35,8 @@ const ProductForm = ({
     basicPrice: z.coerce
       .number()
       .nonnegative({ message: "기본 가격을 입력해 주세요." }),
+    basicPlace: z.string().min(1, { message: "촬영 장소를 입력해 주세요." }),
+    allowPreferredPlace: z.boolean(),
     items: z.array(
       z.object({
         title: z

--- a/src/containers/photographer/product/new-product.tsx
+++ b/src/containers/photographer/product/new-product.tsx
@@ -14,6 +14,8 @@ const NewProduct = () => {
     title: "",
     subtitle: "",
     basicPrice: 0,
+    basicPlace: "",
+    allowPreferredPlace: false,
     items: [
       {
         title: "촬영 시간",
@@ -31,6 +33,13 @@ const NewProduct = () => {
         title: "보정본 추가",
         isFree: false,
         description: "",
+        price: 0,
+      },
+      {
+        title: "포트폴리오 업로드 미동의",
+        isFree: true,
+        description:
+          "해당 옵션을 선택하지 않을 경우, 촬영된 사진이 인스타그램에 업로드되어 포트폴리오로 사용될 수 있습니다.",
         price: 0,
       },
     ],

--- a/src/containers/photographer/reservation/section/control/confirm.tsx
+++ b/src/containers/photographer/reservation/section/control/confirm.tsx
@@ -14,28 +14,35 @@ import StatusModal from "./status-modal";
 import CancelModal from "./cancel-modal";
 import ShootingDate from "./shooting-date";
 import DateModal from "./date-modal";
+import ShootingPlace from "./shooting-place";
 
 const Confirm = () => {
+  const [isEditing, setIsEditing] = useState(false);
   const [opened, { open, close }] = useDisclosure(false);
   const [cancelOpened, { open: openCancel, close: closeCancel }] =
     useDisclosure(false);
   const [dateOpened, { open: openDate, close: closeDate }] =
     useDisclosure(false);
   const { watch } = useFormContext<Details>();
-  const [options, currentStatus, shootingDate] = watch([
+  const [options, currentStatus, shootingDate, basicPrice] = watch([
     "options",
     "currentStatus",
     "shootingDate",
+    "basicPrice",
   ]);
   const prices = options.map((option) => option.price);
   const [totalPrice, setTotalPrice] = useState(0);
 
   useEffect(() => {
-    const newPrice = prices.reduce((sum, price) => sum + price, 0);
+    const newPrice = prices.reduce((sum, price) => sum + price, 0) + basicPrice;
     if (newPrice !== totalPrice) {
       setTotalPrice(newPrice);
     }
-  }, [prices, totalPrice]);
+  }, [prices, totalPrice, basicPrice]);
+
+  function handlePutNewDetails() {
+    setIsEditing(false);
+  }
 
   return (
     <div>
@@ -44,33 +51,74 @@ const Confirm = () => {
       </span>
       <div className={sectionStyles.box}>
         <div className={sectionStyles.divider}>
-          <span className={sectionStyles.title}>기본 가격</span>
-          <TextInput<Details>
-            disabled
-            inputSize="sm"
-            formField="basicPrice"
-            container={{ flex: 1 }}
-          />
-          <span className={sectionStyles.title}>추가 옵션</span>
-          <div className={sectionStyles.optionWrapper}>
-            {options.map((option, index) => (
-              <OptionField key={option.title} optionIndex={index} />
-            ))}
+          <ShootingPlace isEditing={isEditing} />
+          <div>
+            <ShootingDate
+              needShootingDate={
+                compareStatus(currentStatus, "NEW") === "DONE" &&
+                shootingDate === undefined
+              }
+            />
+            {isEditing && (
+              <CustomButton
+                size="sm"
+                styleType="line"
+                onClick={openDate}
+                title="일정 변경하기"
+                style={{ flex: 1, marginTop: 10 }}
+              />
+            )}
+          </div>
+          <div className={sectionStyles.priceWrapper}>
+            <span className={sectionStyles.title}>총 가격</span>
+            <span className={sectionStyles.price}>
+              {formatPrice(totalPrice)}
+            </span>
           </div>
         </div>
-        <div className={sectionStyles.priceWrapper}>
-          <span className={sectionStyles.title}>총 가격</span>
-          <span className={sectionStyles.price}>{formatPrice(totalPrice)}</span>
-        </div>
-        <ShootingDate
-          needShootingDate={
-            compareStatus(currentStatus, "NEW") === "DONE" &&
-            shootingDate === undefined
-          }
+        <span className={sectionStyles.title}>기본 가격</span>
+        <TextInput<Details>
+          disabled
+          inputSize="sm"
+          formField="basicPrice"
+          container={{ flex: 1 }}
         />
-        {isActiveStatus(currentStatus) && (
-          <div className={sectionStyles.buttonWrapper}>
-            <div className={sectionStyles.wrapper}>
+        <span className={sectionStyles.title}>추가 옵션</span>
+        <div className={sectionStyles.optionWrapper}>
+          {options.map((option, index) => (
+            <OptionField key={option.title} optionIndex={index} />
+          ))}
+        </div>
+
+        {isActiveStatus(currentStatus) &&
+          (isEditing ? (
+            <div className={sectionStyles.buttonWrapper}>
+              <CustomButton
+                title="저장하기"
+                size="sm"
+                styleType="primary"
+                onClick={handlePutNewDetails}
+              />
+              <DateModal close={closeDate} opened={dateOpened} />
+            </div>
+          ) : (
+            <div className={sectionStyles.buttonWrapper}>
+              <div className={sectionStyles.wrapper}>
+                <CustomButton
+                  title="거절하기"
+                  onClick={openCancel}
+                  styleType="secondary"
+                  size="sm"
+                  style={{ flex: 1 }}
+                />
+                <CustomButton
+                  size="sm"
+                  styleType="line"
+                  onClick={() => setIsEditing(true)}
+                  title="수정하기"
+                  style={{ flex: 1 }}
+                />
+              </div>
               <CustomButton
                 title={progressStatus[currentStatus]}
                 onClick={open}
@@ -80,31 +128,15 @@ const Confirm = () => {
                   compareStatus(currentStatus, "NEW") === "DONE" &&
                   shootingDate === undefined
                 }
-                style={{ flex: 1 }}
               />
-              <CustomButton
-                size="sm"
-                styleType="line"
-                onClick={openDate}
-                title="일정 변경하기"
-                style={{ flex: 1 }}
+              <StatusModal
+                close={close}
+                opened={opened}
+                targetStatus={getTargetStatus(currentStatus)}
               />
+              <CancelModal close={closeCancel} opened={cancelOpened} />
             </div>
-            <CustomButton
-              title="거절하기"
-              onClick={openCancel}
-              styleType="secondary"
-              size="sm"
-            />
-            <StatusModal
-              close={close}
-              opened={opened}
-              targetStatus={getTargetStatus(currentStatus)}
-            />
-            <CancelModal close={closeCancel} opened={cancelOpened} />
-            <DateModal close={closeDate} opened={dateOpened} />
-          </div>
-        )}
+          ))}
       </div>
     </div>
   );

--- a/src/containers/photographer/reservation/section/control/confirm.tsx
+++ b/src/containers/photographer/reservation/section/control/confirm.tsx
@@ -3,7 +3,6 @@ import { useRouter } from "next/navigation";
 import { useFormContext } from "react-hook-form";
 import { Details } from "reservation-types";
 import { CustomButton } from "@/components/buttons/common-buttons";
-import TextInput from "@/components/inputs/text-input";
 import popToast from "@/components/common/toast";
 import { putReservationDetails } from "@/services/client/photographer/reservations";
 import { responseHandler } from "@/services/common/error";
@@ -92,27 +91,31 @@ const Confirm = () => {
               />
             )}
           </div>
+        </div>
+        <div className={sectionStyles.divider}>
           <div className={sectionStyles.priceWrapper}>
             <span className={sectionStyles.title}>총 가격</span>
             <span className={sectionStyles.price}>
               {formatPrice(totalPrice)}
             </span>
           </div>
+          <div className={sectionStyles.priceWrapper}>
+            <span className={sectionStyles.title}>기본 가격</span>
+            <span className={sectionStyles.content}>
+              {formatPrice(basicPrice)}
+            </span>
+          </div>
+          {options.length > 0 && (
+            <div>
+              <span className={sectionStyles.title}>추가 옵션</span>
+              <div className={sectionStyles.optionWrapper}>
+                {options.map((option) => (
+                  <OptionField key={option.title} option={option} />
+                ))}
+              </div>
+            </div>
+          )}
         </div>
-        <span className={sectionStyles.title}>기본 가격</span>
-        <TextInput<Details>
-          disabled
-          inputSize="sm"
-          formField="basicPrice"
-          container={{ flex: 1 }}
-        />
-        <span className={sectionStyles.title}>추가 옵션</span>
-        <div className={sectionStyles.optionWrapper}>
-          {options.map((option, index) => (
-            <OptionField key={option.title} optionIndex={index} />
-          ))}
-        </div>
-
         {isActiveStatus(currentStatus) &&
           (isEditing ? (
             <div className={sectionStyles.buttonWrapper}>

--- a/src/containers/photographer/reservation/section/control/date-modal.tsx
+++ b/src/containers/photographer/reservation/section/control/date-modal.tsx
@@ -56,7 +56,7 @@ const DateModal = ({
       setValue("shootingDate", {
         date: formatDateString(dateValue.date),
         startTime: parseTimeRequest(dateValue.startTime, "00:00"),
-        endTime: parseTimeRequest(dateValue.endTime, "24:00"),
+        endTime: parseTimeRequest(dateValue.endTime, "23:59"),
       });
       close();
     }

--- a/src/containers/photographer/reservation/section/control/date-modal.tsx
+++ b/src/containers/photographer/reservation/section/control/date-modal.tsx
@@ -1,16 +1,12 @@
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import { useFormContext } from "react-hook-form";
 import { Details } from "reservation-types";
 import { reservation } from "product-types";
 import { Modal } from "@mantine/core";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import ScheduleCalender from "@/components/calender/schedule-calender";
-import popToast from "@/components/common/toast";
 import InputStyles from "@/components/inputs/input.css";
 import { modalStyles } from "@/containers/customer/products/products.css";
-import { responseHandler } from "@/services/common/error";
-import { putShootingDate } from "@/services/client/photographer/reservations";
 import {
   createDateObjects,
   formatDate,
@@ -28,20 +24,16 @@ const DateModal = ({
   opened: boolean;
   close: () => void;
 }) => {
-  const router = useRouter();
-  const { watch } = useFormContext<Details>();
+  const { watch, setValue } = useFormContext<Details>();
   const [dateValue, setDateValue] = useState<reservation.ScheduleListType>({
     date: null,
     endTime: null,
     startTime: null,
   });
-  const [reservationNumber, shootingDate, preferredDates, currentStatus] =
-    watch([
-      "reservationNumber",
-      "shootingDate",
-      "preferredDates",
-      "currentStatus",
-    ]);
+  const [shootingDate, preferredDates] = watch([
+    "shootingDate",
+    "preferredDates",
+  ]);
 
   useEffect(() => {
     if (shootingDate) {
@@ -61,41 +53,29 @@ const DateModal = ({
       dateValue.endTime !== null &&
       dateValue.startTime !== null
     ) {
-      await responseHandler(
-        putShootingDate(
-          reservationNumber,
-          {
-            date: formatDateString(dateValue.date),
-            startTime: parseTimeRequest(dateValue.startTime, "00:00"),
-            endTime: parseTimeRequest(dateValue.endTime, "24:00"),
-          },
-          currentStatus,
-        ),
-        () => {
-          close();
-          popToast("일정이 변경되었습니다.");
-          router.refresh();
-        },
-        () => {
-          popToast("다시 시도해주세요.", "수정에 실패했습니다.", true);
-        },
-      );
+      setValue("shootingDate", {
+        date: formatDateString(dateValue.date),
+        startTime: parseTimeRequest(dateValue.startTime, "00:00"),
+        endTime: parseTimeRequest(dateValue.endTime, "24:00"),
+      });
+      close();
     }
   }
 
   return (
     <Modal
       centered
+      title="촬영 일정을 변경해주세요."
       opened={opened}
       onClose={close}
       classNames={{ ...modalStyles, content: customModalStyles.dateContent }}
     >
-      <div className={sectionStyles.title}>촬영 일정을 변경해주세요.</div>
       <div className={customModalStyles.dateSelect}>
         <ScheduleCalender value={dateValue} setValue={setDateValue} size="md" />
         <div className={customModalStyles.preferredDate}>
-          <div className={sectionStyles.message}>후보 일정에서 선택하기</div>
-
+          {preferredDates.length > 0 && (
+            <div className={sectionStyles.message}>후보 일정에서 선택하기</div>
+          )}
           {preferredDates.map((value, index) => (
             <div
               key={`${index} ${value.date}`}

--- a/src/containers/photographer/reservation/section/control/shooting-place.tsx
+++ b/src/containers/photographer/reservation/section/control/shooting-place.tsx
@@ -1,0 +1,35 @@
+import { useFormContext } from "react-hook-form";
+import { Details } from "reservation-types";
+import TextInput from "@/components/inputs/text-input";
+import { sectionStyles } from "../section.css";
+import { dateStyles } from "./control.css";
+
+const ShootingPlace = ({ isEditing }: { isEditing: boolean }) => {
+  const { watch } = useFormContext<Details>();
+  const shootingPlace = watch("shootingPlace");
+
+  return (
+    <div>
+      <div className={sectionStyles.wrapper}>
+        <span className={sectionStyles.title}>촬영 장소</span>
+        {!isEditing &&
+          (shootingPlace ? (
+            <span className={sectionStyles.price}>{shootingPlace}</span>
+          ) : (
+            <span className={dateStyles.info}>
+              아직 장소가 확정되지 않았어요.
+            </span>
+          ))}
+      </div>
+      {isEditing && (
+        <TextInput<Details>
+          formField="shootingPlace"
+          placeholder="장소를 입력해주세요."
+          container={{ margin: 0 }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ShootingPlace;

--- a/src/containers/photographer/reservation/section/control/shooting-place.tsx
+++ b/src/containers/photographer/reservation/section/control/shooting-place.tsx
@@ -25,7 +25,7 @@ const ShootingPlace = ({ isEditing }: { isEditing: boolean }) => {
         <TextInput<Details>
           formField="shootingPlace"
           placeholder="장소를 입력해주세요."
-          container={{ margin: 0 }}
+          container={{ marginTop: 0 }}
         />
       )}
     </div>

--- a/src/containers/photographer/reservation/section/details/index.tsx
+++ b/src/containers/photographer/reservation/section/details/index.tsx
@@ -1,15 +1,22 @@
+import { useFormContext } from "react-hook-form";
+import { Details } from "reservation-types";
 import CustomerDetails from "./customer-details";
 import PhotoDetails from "./photo-details";
 import ScheduleDetails from "./schedule-details";
 import ImageDetails from "./image-details";
 import RequestDetails from "./request-details";
+import PlaceDetails from "./place-details";
 
 const ReservationDetails = () => {
+  const { watch } = useFormContext<Details>();
+  const preferredPlace = watch("preferredPlace");
+
   return (
     <div>
       <CustomerDetails />
       <PhotoDetails />
       <ScheduleDetails />
+      {preferredPlace && <PlaceDetails />}
       <ImageDetails />
       <RequestDetails />
     </div>

--- a/src/containers/photographer/reservation/section/details/photo-details.tsx
+++ b/src/containers/photographer/reservation/section/details/photo-details.tsx
@@ -6,10 +6,11 @@ import { sectionStyles } from "../section.css";
 
 const PhotoDetails = () => {
   const { watch } = useFormContext<Details>();
-  const details = watch("productInfo");
+  const [details] = watch(["productInfo"]);
   return (
     <SectionLayout title="촬영 정보">
       <div className={sectionStyles.wrapper}>
+        <Field key="촬영 장소" name="촬영 장소" formField="basicPlace" />
         {details.map((detail, index) => (
           <Field
             key={detail.title}

--- a/src/containers/photographer/reservation/section/details/place-details.tsx
+++ b/src/containers/photographer/reservation/section/details/place-details.tsx
@@ -1,0 +1,21 @@
+import { useFormContext } from "react-hook-form";
+import { Details } from "reservation-types";
+import TextInput from "@/components/inputs/text-input";
+import SectionLayout from "../section-layout";
+
+const PlaceDetails = () => {
+  const { watch } = useFormContext<Details>();
+  const details = watch("preferredPlace");
+
+  return (
+    <SectionLayout title="희망 장소">
+      <TextInput<Details>
+        disabled
+        formField="preferredPlace"
+        container={{ marginBottom: 0 }}
+      />
+    </SectionLayout>
+  );
+};
+
+export default PlaceDetails;

--- a/src/containers/photographer/reservation/section/fields/option-field.tsx
+++ b/src/containers/photographer/reservation/section/fields/option-field.tsx
@@ -1,34 +1,13 @@
-import { Details } from "reservation-types";
-import TextInput from "@/components/inputs/text-input";
+import { Option } from "reservation-types";
+import { formatPrice } from "@/utils/parse";
 import { fieldStyles } from "../section.css";
 
-interface FieldProps {
-  isEditing?: boolean;
-  optionIndex: number;
-}
-
-const OptionField = ({ isEditing = false, optionIndex }: FieldProps) => {
+const OptionField = ({ option }: { option: Option }) => {
   return (
     <div className={fieldStyles.option}>
-      <TextInput<Details>
-        disabled
-        inputSize="sm"
-        formField={`options.${optionIndex}.title`}
-        container={{ flex: 1, margin: 0, width: "35%", minWidth: 0 }}
-      />
-      <TextInput<Details>
-        placeholder="0"
-        disabled={!isEditing}
-        inputSize="sm"
-        formField={`options.${optionIndex}.quantity`}
-        container={{ flex: 0.6, margin: 0, width: "25%", minWidth: 0 }}
-      />
-      <TextInput<Details>
-        disabled
-        inputSize="sm"
-        formField={`options.${optionIndex}.price`}
-        container={{ flex: 1, margin: 0, width: "35%", minWidth: 0 }}
-      />
+      <span className={fieldStyles.name}>{option.title}</span>
+      <span className={fieldStyles.name}>{option.quantity}</span>
+      <span className={fieldStyles.content}>{formatPrice(option.price)}</span>
     </div>
   );
 };

--- a/src/containers/photographer/reservation/section/section.css.ts
+++ b/src/containers/photographer/reservation/section/section.css.ts
@@ -52,6 +52,9 @@ export const sectionStyles = styleVariants({
       marginBottom: 20,
       borderBottomWidth: 1,
       borderBottomStyle: "solid",
+      display: "flex",
+      flexDirection: "column",
+      gap: 30,
     },
   ],
   scheduleWrapper: [
@@ -90,7 +93,6 @@ export const sectionStyles = styleVariants({
     display: "flex",
     justifyContent: "space-between",
     alignItems: "flex-start",
-    margin: "28px 0px",
     gap: 20,
   },
   buttonWrapper: {

--- a/src/containers/photographer/reservation/section/section.css.ts
+++ b/src/containers/photographer/reservation/section/section.css.ts
@@ -54,7 +54,7 @@ export const sectionStyles = styleVariants({
       borderBottomStyle: "solid",
       display: "flex",
       flexDirection: "column",
-      gap: 30,
+      gap: 20,
     },
   ],
   scheduleWrapper: [
@@ -78,16 +78,14 @@ export const sectionStyles = styleVariants({
       overflowX: "scroll",
     },
   ],
-  optionWrapper: [
-    baseWrapper,
-    { gap: 10, flexDirection: "column", padding: "10px 0px" },
-  ],
+  optionWrapper: [baseWrapper, { gap: 10, flexDirection: "column" }],
   title: [
     texts["headline-02"],
     sprinkles({ color: "text-02" }),
     { minWidth: "fit-content" },
   ],
   price: [texts["headline-02"], sprinkles({ color: "blue" })],
+  content: [texts["headline-03"], sprinkles({ color: "blue" })],
   message: [texts["headline-03"], sprinkles({ color: "text-point" })],
   priceWrapper: {
     display: "flex",
@@ -125,8 +123,16 @@ export const fieldStyles = styleVariants({
     width: "100%",
     gap: 12,
     display: "flex",
+    justifyContent: "space-between",
+    margin: "8px 0px",
     position: "relative",
   },
+  name: [
+    texts["headline-03"],
+    sprinkles({ color: "text-03" }),
+    { minWidth: 60 },
+  ],
+  content: [texts["headline-03"], sprinkles({ color: "blue" })],
 });
 
 export const titleStyles = styleVariants({

--- a/src/services/client/customer/reservation.ts
+++ b/src/services/client/customer/reservation.ts
@@ -9,14 +9,13 @@ export async function postReservation(form: reservation.FormType) {
     profileName: form.profileName,
     productId: form.productId,
     instagramId: form.instagram,
-    // TODO: 백엔드 api 명세 검토
     preferredPlace: form.preferredPlace === "" ? null : form.preferredPlace,
     preferredDates: arrayToObject(
       form.schedules.map((schedule) => {
         return {
           ...schedule,
           startTime: parseTimeRequest(schedule.startTime, "00:00"),
-          endTime: parseTimeRequest(schedule.endTime, "24:00"),
+          endTime: parseTimeRequest(schedule.endTime, "23:59"),
         };
       }),
     ),

--- a/src/services/client/customer/reservation.ts
+++ b/src/services/client/customer/reservation.ts
@@ -9,6 +9,8 @@ export async function postReservation(form: reservation.FormType) {
     profileName: form.profileName,
     productId: form.productId,
     instagramId: form.instagram,
+    // TODO: 백엔드 api 명세 검토
+    preferredPlace: form.preferredPlace === "" ? null : form.preferredPlace,
     preferredDates: arrayToObject(
       form.schedules.map((schedule) => {
         return {

--- a/src/services/client/photographer/products.ts
+++ b/src/services/client/photographer/products.ts
@@ -21,7 +21,6 @@ export async function postNewProduct(
 ) {
   const formData = new FormData();
   const inputData = {
-    // TODO: 백엔드 api 명세 검토
     productTitle: form.title,
     productDescription: form.subtitle,
     basicPrice: form.basicPrice,
@@ -99,7 +98,6 @@ export async function putProductDetails(
     allowPreferredPlace,
   } = newDetails;
   const inputData = {
-    // TODO: 백엔드 api 명세 검토
     basicPrice,
     basicPlace,
     allowPreferredPlace,

--- a/src/services/client/photographer/products.ts
+++ b/src/services/client/photographer/products.ts
@@ -21,9 +21,12 @@ export async function postNewProduct(
 ) {
   const formData = new FormData();
   const inputData = {
+    // TODO: 백엔드 api 명세 검토
     productTitle: form.title,
-    basicPrice: form.basicPrice,
     productDescription: form.subtitle,
+    basicPrice: form.basicPrice,
+    basicPlace: form.basicPlace,
+    preferredPlaceAvailability: form.preferredPlaceAvailability,
     productComponents: form.items.map((item) => {
       return {
         title: item.title,
@@ -85,9 +88,21 @@ export async function putProductDetails(
   productId: string,
 ) {
   const formData = new FormData();
-  const { title, subtitle, items, options, discounts, basicPrice } = newDetails;
-  const inputData = {
+  const {
+    title,
+    subtitle,
+    items,
+    options,
+    discounts,
     basicPrice,
+    basicPlace,
+    preferredPlaceAvailability,
+  } = newDetails;
+  const inputData = {
+    // TODO: 백엔드 api 명세 검토
+    basicPrice,
+    basicPlace,
+    preferredPlaceAvailability,
     productId: parseInt(productId, PARAMETER_DEFAULT_RADIX),
     existingUrls: newImages.map((image) => {
       return image.file !== undefined ? null : image.url;

--- a/src/services/client/photographer/products.ts
+++ b/src/services/client/photographer/products.ts
@@ -26,7 +26,7 @@ export async function postNewProduct(
     productDescription: form.subtitle,
     basicPrice: form.basicPrice,
     basicPlace: form.basicPlace,
-    preferredPlaceAvailability: form.preferredPlaceAvailability,
+    allowPreferredPlace: form.allowPreferredPlace,
     productComponents: form.items.map((item) => {
       return {
         title: item.title,
@@ -96,13 +96,13 @@ export async function putProductDetails(
     discounts,
     basicPrice,
     basicPlace,
-    preferredPlaceAvailability,
+    allowPreferredPlace,
   } = newDetails;
   const inputData = {
     // TODO: 백엔드 api 명세 검토
     basicPrice,
     basicPlace,
-    preferredPlaceAvailability,
+    allowPreferredPlace,
     productId: parseInt(productId, PARAMETER_DEFAULT_RADIX),
     existingUrls: newImages.map((image) => {
       return image.file !== undefined ? null : image.url;

--- a/src/services/client/photographer/reservations.ts
+++ b/src/services/client/photographer/reservations.ts
@@ -96,7 +96,7 @@ export async function putReservationDetails(
     currentReservationStatus: currentStatus,
   };
   await apiClient.put(
-    `photographer/reservation/shooting-date/${reservationNumber}`,
+    `photographer/reservation/shooting-info/${reservationNumber}`,
     {
       json: body,
     },

--- a/src/services/client/photographer/reservations.ts
+++ b/src/services/client/photographer/reservations.ts
@@ -1,7 +1,7 @@
 import {
   ActiveStatus,
+  Details,
   Infos,
-  ReservationDate,
   ReservationList,
   ReservationListResponse,
   ReservationSearchParams,
@@ -82,18 +82,25 @@ export async function putReservationStatus(
   });
 }
 
-export async function putShootingDate(
-  id: number,
-  shootingDate: ReservationDate,
-  currentStatus: Status,
+export async function putReservationDetails(
+  details: Pick<
+    Details,
+    "reservationNumber" | "currentStatus" | "shootingDate" | "shootingPlace"
+  >,
 ) {
+  const { reservationNumber, currentStatus, shootingDate, shootingPlace } =
+    details;
   const body = {
-    newShootingDate: shootingDate,
+    newShootingDate: shootingDate || null,
+    newShootingPlace: shootingPlace || null,
     currentReservationStatus: currentStatus,
   };
-  await apiClient.put(`photographer/reservation/shooting-date/${id}`, {
-    json: body,
-  });
+  await apiClient.put(
+    `photographer/reservation/shooting-date/${reservationNumber}`,
+    {
+      json: body,
+    },
+  );
 }
 
 export async function putMemo(id: number, memo: string) {

--- a/src/services/server/customer/product.ts
+++ b/src/services/server/customer/product.ts
@@ -1,4 +1,8 @@
-import { Product, ProductListData } from "product-types";
+import {
+  Product,
+  ProductDetailResponseData,
+  ProductListData,
+} from "product-types";
 import { normalizeDescription } from "@/utils/product";
 import { api } from "../core";
 
@@ -26,37 +30,15 @@ export async function getProductList(
   });
 }
 
-interface ProductDetailResponseData {
-  productTitle: string;
-  productDescription: string;
-  productImageUrls: string[];
-  basicPrice: number;
-  productComponents: {
-    title: string;
-    content: string;
-    description: null | string;
-  }[];
-  productOptions: {
-    title: string;
-    price: number;
-    description: null | string;
-  }[];
-  productDiscounts: {
-    title: string;
-    discountType: "RATE" | "AMOUNT";
-    discountValue: number;
-    description: null | string;
-  }[];
-}
-
 export async function getProductDetails(productId: string): Promise<Product> {
   const response = await api
     .get(`customer/product/details/${productId}`)
     .json<{ data: ProductDetailResponseData }>();
   const { data } = response;
   return {
+    ...data,
     title: data.productTitle,
-    subtitle: data.productDescription,
+    subtitle: data.productDescription || "",
     basicPrice: data.basicPrice,
     images: data.productImageUrls,
     items: normalizeDescription(data.productComponents),

--- a/src/services/server/customer/reservation.ts
+++ b/src/services/server/customer/reservation.ts
@@ -1,4 +1,4 @@
-import { Item, Option, reservation } from "product-types";
+import { Product, reservation } from "product-types";
 import {
   CustomerDetails,
   CustomerReservationResponse,
@@ -22,14 +22,19 @@ interface FormDataResponse {
     price: number;
     description: string | null;
   }[];
+  // TODO: 백엔드 api 명세 검토
+  basicPlace: string;
+  allowPreferredPlace: boolean;
 }
 
-export async function getFormBase(productId: string): Promise<
-  Pick<reservation.FormType, "name" | "contact" | "instagram"> & {
-    options: Option[];
-    items: Item[];
-    basicPrice: number;
-  }
+export async function getFormBase(
+  productId: string,
+): Promise<
+  Pick<reservation.FormType, "name" | "contact" | "instagram"> &
+    Pick<
+      Product,
+      "options" | "items" | "basicPlace" | "basicPrice" | "allowPreferredPlace"
+    >
 > {
   const response = await api
     .get(`customer/reservation/form/${productId}`)
@@ -37,6 +42,7 @@ export async function getFormBase(productId: string): Promise<
   const { data } = response;
 
   return {
+    ...data,
     name: data.name,
     contact: data.phoneNumber,
     basicPrice: data.basicPrice,

--- a/src/services/server/customer/reservation.ts
+++ b/src/services/server/customer/reservation.ts
@@ -22,7 +22,6 @@ interface FormDataResponse {
     price: number;
     description: string | null;
   }[];
-  // TODO: 백엔드 api 명세 검토
   basicPlace: string;
   allowPreferredPlace: boolean;
 }

--- a/src/services/server/customer/reservation.ts
+++ b/src/services/server/customer/reservation.ts
@@ -112,7 +112,7 @@ export async function getReservationDetails(
       options
         .map((option) => option.price)
         .reduce((sum: number, price: number) => sum + price, 0),
-    notices: objectToArray(data.notices, (arr) =>
+    notices: objectToArray(data.photoNotice, (arr) =>
       arr.sort().map(([_, content]) => content),
     ),
   };

--- a/src/services/server/customer/reservation.ts
+++ b/src/services/server/customer/reservation.ts
@@ -96,6 +96,8 @@ export async function getReservationDetails(
     options,
     currentStatus,
     shootingDate: data.shootingDate || undefined,
+    preferredPlace: data.preferredPlace || undefined,
+    shootingPlace: data.shootingPlace || undefined,
     preferredDates: objectToArray(data.preferredDate, (arr) =>
       arr.sort().map(([_, content]) => content),
     ),

--- a/src/services/server/photographer/mypage/products.ts
+++ b/src/services/server/photographer/mypage/products.ts
@@ -44,7 +44,7 @@ export async function getCurrentProductDetails(
     productDiscounts,
     productImageUrls,
     basicPlace,
-    preferredPlaceAvailability,
+    allowPreferredPlace,
   } = data;
 
   const currentDetails: ProductFormdata = {
@@ -52,7 +52,7 @@ export async function getCurrentProductDetails(
     subtitle: productDescription || "",
     basicPrice,
     basicPlace,
-    preferredPlaceAvailability,
+    allowPreferredPlace,
     items: productComponents.map((component) => {
       return {
         ...component,

--- a/src/services/server/photographer/mypage/products.ts
+++ b/src/services/server/photographer/mypage/products.ts
@@ -43,12 +43,16 @@ export async function getCurrentProductDetails(
     productComponents,
     productDiscounts,
     productImageUrls,
+    basicPlace,
+    preferredPlaceAvailability,
   } = data;
 
   const currentDetails: ProductFormdata = {
     title: productTitle,
     subtitle: productDescription || "",
     basicPrice,
+    basicPlace,
+    preferredPlaceAvailability,
     items: productComponents.map((component) => {
       return {
         ...component,

--- a/src/services/server/photographer/reservation.ts
+++ b/src/services/server/photographer/reservation.ts
@@ -45,6 +45,8 @@ export async function getReservationDetail(formId: string): Promise<Details> {
     ...data,
     statusHistory,
     currentStatus,
+    preferredPlace: data.preferredPlace || undefined,
+    shootingPlace: data.shootingPlace || undefined,
     cancelStatus: data.statusBeforeCancellation,
     customer: data.customerDetails,
     photographerMemo: data.photographerMemo || "",

--- a/src/services/server/photographer/reservation.ts
+++ b/src/services/server/photographer/reservation.ts
@@ -63,7 +63,7 @@ export async function getReservationDetail(formId: string): Promise<Details> {
     options: objectToArray(data.photoOptions, (arr) =>
       arr.map(([_, content]) => content),
     ),
-    notices: objectToArray(data.notices, (arr) =>
+    notices: objectToArray(data.photoNotice, (arr) =>
       arr.sort().map(([_, content]) => content),
     ),
   };

--- a/src/types/product-types.d.ts
+++ b/src/types/product-types.d.ts
@@ -59,7 +59,6 @@ declare module "product-types" {
     productDescription: string | null;
     productImageUrls: string[];
     basicPrice: number;
-    // TODO: 백엔드 api 명세 검토 필요
     basicPlace: string;
     allowPreferredPlace: boolean;
     productComponents: {

--- a/src/types/product-types.d.ts
+++ b/src/types/product-types.d.ts
@@ -32,6 +32,8 @@ declare module "product-types" {
     subtitle: string;
     images: Image[];
     basicPrice: number;
+    basicPlace: string;
+    preferredPlaceAvailability: boolean;
     items: Item[];
     options: Option[];
     discounts: Discount[];
@@ -57,6 +59,9 @@ declare module "product-types" {
     productDescription: string | null;
     productImageUrls: string[];
     basicPrice: number;
+    // TODO: 백엔드 api 명세 검토 필요
+    basicPlace: string;
+    preferredPlaceAvailability: boolean;
     productComponents: {
       title: string;
       content: string;

--- a/src/types/product-types.d.ts
+++ b/src/types/product-types.d.ts
@@ -33,7 +33,7 @@ declare module "product-types" {
     images: Image[];
     basicPrice: number;
     basicPlace: string;
-    preferredPlaceAvailability: boolean;
+    allowPreferredPlace: boolean;
     items: Item[];
     options: Option[];
     discounts: Discount[];
@@ -61,7 +61,7 @@ declare module "product-types" {
     basicPrice: number;
     // TODO: 백엔드 api 명세 검토 필요
     basicPlace: string;
-    preferredPlaceAvailability: boolean;
+    allowPreferredPlace: boolean;
     productComponents: {
       title: string;
       content: string;

--- a/src/types/product-types.d.ts
+++ b/src/types/product-types.d.ts
@@ -113,6 +113,7 @@ declare module "product-types" {
       schedules: ScheduleListType[];
       options: SelectedOption[];
       memo: string;
+      preferredPlace: string;
       referenceImages: FormImage[];
       totalPrice: number;
       serviceAgreement: boolean;

--- a/src/types/profile-types.d.ts
+++ b/src/types/profile-types.d.ts
@@ -17,7 +17,6 @@ declare module "profile-types" {
     linkInfos: { linkTitle: string; linkUrl: string }[];
   }
 
-  // TODO: 백엔드 api 명세 확인 필요
   interface PhotographerProfileResponse extends ProfileResponse {
     contact: string;
   }

--- a/src/types/reservation-types.d.ts
+++ b/src/types/reservation-types.d.ts
@@ -20,8 +20,6 @@ declare module "reservation-types" {
     quantity: number;
     price: number;
   }
-
-  // TODO: 백엔드 신청서 상세조회 api 명세 검토
   interface BaseDetails {
     currentStatus: Status;
     cancelStatus?: Status;
@@ -32,6 +30,7 @@ declare module "reservation-types" {
     preferredPlace?: string;
     shootingPlace?: string;
     basicPrice: number;
+    basicPlace: string;
     options: Option[];
     requestMemo: string;
   }
@@ -45,6 +44,7 @@ declare module "reservation-types" {
     shootingDate: null | ReservationDate;
     shootingPlace: null | string;
     basicPrice: number;
+    basicPlace: string;
   }
 
   type ActiveStatus =

--- a/src/types/reservation-types.d.ts
+++ b/src/types/reservation-types.d.ts
@@ -21,6 +21,7 @@ declare module "reservation-types" {
     price: number;
   }
 
+  // TODO: 백엔드 신청서 상세조회 api 명세 검토
   interface BaseDetails {
     currentStatus: Status;
     cancelStatus?: Status;
@@ -28,6 +29,8 @@ declare module "reservation-types" {
     productInfo: { title: string; content: string }[];
     preferredDates: ReservationDate[];
     shootingDate?: ReservationDate;
+    preferredPlace?: string;
+    shootingPlace?: string;
     basicPrice: number;
     options: Option[];
     requestMemo: string;
@@ -38,7 +41,9 @@ declare module "reservation-types" {
     statusBeforeCancellation?: Status;
     photoInfo: { [key: string]: string };
     photoOptions: { [key: string]: Option };
+    preferredPlace: null | string;
     shootingDate: null | ReservationDate;
+    shootingPlace: null | string;
     basicPrice: number;
   }
 

--- a/src/types/reservation-types.d.ts
+++ b/src/types/reservation-types.d.ts
@@ -47,7 +47,7 @@ declare module "reservation-types" {
     photoInfo: { [key: string]: string };
     photoOptions: { [key: string]: Option };
     preferredPlace: null | string;
-    notices: { [key: string]: Notice };
+    photoNotice: { [key: string]: Notice };
     shootingDate: null | ReservationDate;
     shootingPlace: null | string;
     basicPrice: number;


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
### 상품 필드 수정
* 기본 촬영 장소, 촬영 장소 협의 가능 여부 필드 추가
* (사진작가) 상품 등록, 상품 상세 조회, 상품 상세 정보 수정 기능 변경됨
* (사진의뢰자) 상품 상세 조회 기능 변경됨

### 신청서 필드 수정
* 기본 촬영 장소, 확정 촬영 장소 필드 추가
* 촬영 장소 협의 가능 여부에 따라 희망 장소 입력 및 조회 가능
* (사진작가) 신청서 상세 조회, 촬영일자 업데이트 기능 변경됨
* (사진의뢰자) 신청서 기본 양식 조회, 신청서 등록, 신청서 조회 기능 변경됨

## 고민한 사항
* "촬영 장소 협의 가능 여부" 필드명에 대해 고민이 있었습니다. (한글로 써도 긴… 😌) 처음에는 `preferredPlaceAvailability`를 사용했었는데, 너무 긴 것 같아서 `allowPreferredPlace`로 변경했습니다! 혹시 더 좋은 아이디어가 있다면 제안해 주세요 😂 (@yuseok0215 같이 고민해 줘서 감사합니다… 🙇)
* 신청서에 항목이 많아지다 보니 UI 수정의 필요성이 생겼습니다. 이전에 언급되었던 내용을 포함해(작가측에서 신청서 상세 사항 수정하는 방식) 신청서 상세 조회 파트의 일부 UIUX가 수정되었습니다. 특히 의뢰자측의 경우 박스가 너무 많아져서 "자신이 신청서에서 요청한 내용" "최종적으로 촬영에 대해 확정된 일정"을 하나로 묶었습니다. (스크린샷 참고해 주세요!)

## 리뷰 요청사항
* 시급도: `높음`
출시 전에 반영되어야 해서 높음이기는 하지만, 백엔드에서 수정 사항 반영한 티켓 먼저 배포한 뒤 api 요청에 대해 테스트 해 보고 병합하는 것도 괜찮을 것 같아요!

* 또 너무 얕고 넓게 건드려서… 😓 일단은 `types` 폴더(추가된 필드에 대한 정의), `services` 폴더(api별 요청 함수 수정)의 파일 위주로 리뷰 부탁드립니닷

## 스크린샷
![스크린샷 2024-10-14 오후 6 43 46](https://github.com/user-attachments/assets/c26ebbbf-f7c9-44cd-9a80-bb1db9598a0a)
![스크린샷 2024-10-14 오후 8 25 09](https://github.com/user-attachments/assets/a5052d07-2af9-4685-996f-6d614ea1eb7c)
