### PR TITLE
[FU-308] Google Analytics login event

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,13 +46,15 @@ export default function RootLayout({
           name="naver-site-verification"
           content="2a75aaab03248bdbc9a65fec4c3c98687d161403"
         />
-        <GoogleAnalytics gaId="G-HB94Q4DZRD" />
         <ColorSchemeScript />
       </head>
       <body
         className={pretendard.className}
         style={{ overflowX: "hidden", overflowY: "hidden" }}
       >
+        <GoogleAnalytics
+          gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID || ""}
+        />
         <MantineProvider
           theme={{
             colors: {

--- a/src/components/buttons/login-button.tsx
+++ b/src/components/buttons/login-button.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { User } from "user-types";
+import { sendGAEvent } from "@next/third-parties/google";
 import buttonStyles from "./buttons.css";
 
 const LoginButton = ({
@@ -18,8 +19,10 @@ const LoginButton = ({
   };
 
   function loginToKakao() {
+    sendGAEvent("event", "login", { method: "kakao", roleType, destination });
     window.location.href = `${process.env.NEXT_PUBLIC_KAKAO_DOMAIN}oauth/authorize?response_type=code&client_id=${process.env.NEXT_PUBLIC_AUTH_KAKAO_KEY}&redirect_uri=${redirectUri}&state=${JSON.stringify(stateValue)}`;
   }
+
   return (
     <button type="button" onClick={loginToKakao} className={buttonStyles.kakao}>
       <Image


### PR DESCRIPTION
## 체크리스트
- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 구글 애널리틱스에 로그인 이벤트 전송

## 고민한 사항
* 구글 애널리틱스를 통한 사용자 지표 트래킹 방안에 대해 고민이 있었습니다. 현재 생각한 서비스 유입 경로는 아래와 같습니다.
[![](https://mermaid.ink/img/pako:eNptkV1LwlAYx7_Kw7mymHS_i2DOIV2okfMmF3Fwxxdym6ytCCcIrSCTUBKKmqIQiHf5Ehn0ibbjd2gv9nLRuXqe8__9_8_hPA1U1GSCWFSqaefFCtYNEJOSCv7hCu6y5y5GRxCP71p5MX2cy-YPeIEBnkvvc3upjF9lM6KQES1INLyh4_WnsL57pIMlnbSaUUqq4M5b9PIG6EOfTmwG3MUbvR0Andme3QXvfhbmQ2KDh8NSHFBnRIdXQK87tP1i8ZGa-F8FPkZtx_uw_Qa8aZ8OVr_v2IqsfGjd9r3kjKiGBULMGzvu-yqAd2D91KHPXfe1FcR6c3vd_twYhcCYjNFhL1BX4z_JiEEK0RVclf0PbAS4hIwKUYiEWL-UsX4iIUlt-hw2DS13oRYRa-gmYZCumeUKYku4dup3Zl3GBklWcVnHys8tkauGpqej_YRrYlAdq4ea9s00vwCeRLyJ?type=png)](https://mermaid.live/edit#pako:eNptkV1LwlAYx7_Kw7mymHS_i2DOIV2okfMmF3Fwxxdym6ytCCcIrSCTUBKKmqIQiHf5Ehn0ibbjd2gv9nLRuXqe8__9_8_hPA1U1GSCWFSqaefFCtYNEJOSCv7hCu6y5y5GRxCP71p5MX2cy-YPeIEBnkvvc3upjF9lM6KQES1INLyh4_WnsL57pIMlnbSaUUqq4M5b9PIG6EOfTmwG3MUbvR0Andme3QXvfhbmQ2KDh8NSHFBnRIdXQK87tP1i8ZGa-F8FPkZtx_uw_Qa8aZ8OVr_v2IqsfGjd9r3kjKiGBULMGzvu-yqAd2D91KHPXfe1FcR6c3vd_twYhcCYjNFhL1BX4z_JiEEK0RVclf0PbAS4hIwKUYiEWL-UsX4iIUlt-hw2DS13oRYRa-gmYZCumeUKYku4dup3Zl3GBklWcVnHys8tkauGpqej_YRrYlAdq4ea9s00vwCeRLyJ)

(자세한 내용은 티켓 본문 및 컨플루언스에 기록했습니다.) 위와 같은 서비스 유입 - 온보딩 과정을 트래킹하기 위해 필요하다고 예상한 작업은 다음과 같았습니다.
(1) 광고 캠페인 진행시 url에 utm parameter 사용
(2) 서비스 유입 / 로그인 시작 비율을 파악하기 위한 로그인 이벤트 등록
(3) 메인 페이지에서의 사용자 행동 파악

이 중 3번의 경우 메인 페이지 UI 개선과 함께 진행될 필요가 있을 것 같아 보류했고, 이번 티켓에서는 일단 2번만 작업한 상황입니다.

* 테스트 중 로그인 버튼을 한 번 클릭할 때마다 구글 애널리틱스에 두 번씩 등록되는 현상이 있어 이걸 잡느라 시간이 걸렸습니다 🥲… 처음에 단순히 코드만 수정하고 버튼 이벤트를 발생시켰을 때는 보고서에 나타나지 않아서, 구글 애널리틱스 세팅에서 직접 커스텀 이벤트를 등록했습니다. 이렇게 직접 등록하는 건 '로그인 이벤트가 발생시 이벤트를 생성'하는 방식이라 중복이 생겼던 걸로 파악했습니다. 😓 (처음에는 보고서에서 보이기까지 시간 텀이 있어서 발견하지 못했던 것 같습니다!)

## 리뷰 요청사항
* 유입 과정과 관련해 추가로 이벤트가 들어가야 할 것 같은 부분이 있다면 피드백 부탁드려요!

## 스크린샷
![스크린샷 2024-10-17 오후 4 00 47](https://github.com/user-attachments/assets/98ac6c72-87b4-4617-b989-1eb0c468d8fc)
