### PR TITLE
[FU-310] status refresh

### DIFF
--- a/src/containers/photographer/reservation/index.tsx
+++ b/src/containers/photographer/reservation/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { Details } from "reservation-types";
 import { FormProvider, useForm } from "react-hook-form";
 import ReservationDetails from "./section/details";
@@ -10,6 +11,13 @@ import ReservationTitle from "./title";
 
 const ReservationDetailsPage = ({ detailsData }: { detailsData: Details }) => {
   const method = useForm<Details>({ defaultValues: detailsData });
+  const { setValue } = method;
+
+  useEffect(() => {
+    Object.keys(detailsData).forEach((key) => {
+      setValue(key as keyof Details, detailsData[key as keyof Details]);
+    });
+  }, [detailsData, setValue]);
 
   return (
     <FormProvider {...method}>

--- a/src/containers/photographer/reservation/section/control/confirm.tsx
+++ b/src/containers/photographer/reservation/section/control/confirm.tsx
@@ -77,6 +77,20 @@ const Confirm = () => {
     );
   }
 
+  function progressNextStatus() {
+    if (
+      compareStatus(currentStatus, "NEW") === "DONE" &&
+      (shootingDate === undefined || shootingPlace === undefined)
+    ) {
+      popToast(
+        "'수정하기'를 누른 다음 촬영 장소와 일정을 먼저 확정해주세요.",
+        "아직 다음 단계로 넘어갈 수 없어요.",
+      );
+    } else {
+      open();
+    }
+  }
+
   return (
     <div>
       <div className={sectionStyles.header}>
@@ -100,12 +114,7 @@ const Confirm = () => {
         <div className={sectionStyles.divider}>
           <ShootingPlace isEditing={isEditing} />
           <div>
-            <ShootingDate
-              needShootingDate={
-                compareStatus(currentStatus, "NEW") === "DONE" &&
-                shootingDate === undefined
-              }
-            />
+            <ShootingDate />
             {isEditing && (
               <CustomButton
                 size="sm"
@@ -172,13 +181,9 @@ const Confirm = () => {
               </div>
               <CustomButton
                 title={progressStatus[currentStatus]}
-                onClick={open}
+                onClick={progressNextStatus}
                 styleType="primary"
                 size="sm"
-                disabled={
-                  compareStatus(currentStatus, "NEW") === "DONE" &&
-                  shootingDate === undefined
-                }
               />
               <StatusModal
                 close={close}

--- a/src/containers/photographer/reservation/section/control/shooting-date.tsx
+++ b/src/containers/photographer/reservation/section/control/shooting-date.tsx
@@ -4,7 +4,7 @@ import { formatDate, formatTimeString } from "@/utils/date";
 import { sectionStyles } from "../section.css";
 import { dateStyles } from "./control.css";
 
-const ShootingDate = ({ needShootingDate }: { needShootingDate: boolean }) => {
+const ShootingDate = () => {
   const { watch } = useFormContext<Details>();
   const shootingDate = watch("shootingDate");
 
@@ -27,11 +27,6 @@ const ShootingDate = ({ needShootingDate }: { needShootingDate: boolean }) => {
           <span className={dateStyles.info}>
             아직 일정이 확정되지 않았어요.
           </span>
-          {needShootingDate && (
-            <span className={dateStyles.error}>
-              다음으로 진행하기 위해 일정을 먼저 확정해 주세요.
-            </span>
-          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 신청서 상태 변경시 문제 해결
* 일정 및 장소 확정에 대한 안내 방식 변경

### 현상 파악
* 신청서 상세 조회 페이지에서 상태 업데이트 요청을 통해 다음 상태로 진행시킬 경우, (특히 상담 중 > 입금 대기 변경에서) 업데이트된 상태가 화면에 바로 반영되지 않아서 이전 상태 기준으로 표시되는 문제

### 분석하기
* 상태 변경 성공시 router.refresh로 새로고침해서 업데이트된 값을 받아오게 됨
* 상태 변경 영역 외에, 신청서 조회 영역에서는 바로 업데이트가 이루어지고 있었음 (상태를 받아오는 것 자체는 문제 없이 수행됨)
* 초기에는 문제가 발생하는 위치에서 컴포넌트 prop으로 '현재 신청서 상태' 값이 직접 전달되지 않고, 함수를 통해 prop을 구하는 등 업데이트 감지가 불가능하게 되어 있는 건지 의심함
* 확인 결과 해당 문제는 아니었으며, 다만 "정상적으로 업데이트되는 컴포넌트"는 받은 데이터를 바로 prop으로 전달받아 쓰고 있으나, "업데이트 되지 않는 컴포넌트"는 form의 필드에 접근해 값을 쓰고 있음을 확인함 (props drilling 문제, 해당 컴포넌트 내에서는 수정될 수 있는 필드값을 들고 있어야 함)
* 받은 데이터를 form의 defaultValue로 넣어 주고 있으나, 하위 컴포넌트에서 변경을 바로 감지하지 못할 수 있다는 점을 확인

### 조치하기
* api 요청으로 받은 데이터가 변경되었을 경우 form에 직접 setValue를 통해 값을 변경해 줌으로써 변경이 감지되도록 수정

### 검증하기
* 문제가 되었던 상태 변경을 테스트해서 정상적으로 업데이트되는 것을 확인

### 회고
* 문제가 해결되기는 했지만, 테스트하는 중에도 다른 변경에서는 같은 문제가 재현되지 않고 "상담 중 > 입금 대기" 상황에서만 재현되어서… 🤔 여기서만 문제가 생겼던 이유에 대해서는 뾰족하게 알아내지 못했습니다 😂

## 리뷰 요청사항
* 시급도: `높음`
* "상담 중 > 입금 대기" 변경시 무조건 일정과 장소 확정이 필요한데, 이때 확정이 되지 않았을 경우 버튼을 비활성화시키는 방식 > 버튼을 눌렀을 때 확정이 되지 않았을 경우 상태 변경 확인창 대신 토스트 메시지를 띄워주고 종료하는 방식으로 변경했습니다. `progressNextStatus` 함수에서 확인해 주시면 좋을 것 같습니다!