### PR TITLE
[FU-312] logout handler

### DIFF
--- a/src/app/auth/route.ts
+++ b/src/app/auth/route.ts
@@ -35,7 +35,10 @@ export async function DELETE() {
     if (response.redirected) {
       const redirectUrl = response.url;
       if (redirectUrl) {
-        return NextResponse.redirect(redirectUrl);
+        console.log(redirectUrl);
+        return NextResponse.redirect(
+          new URL("/", process.env.NEXT_PUBLIC_DOMAIN),
+        );
       }
       if (response.status === 403) {
         deleteTokens();

--- a/src/containers/photographer/main/sidebar/menu-list.tsx
+++ b/src/containers/photographer/main/sidebar/menu-list.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter } from "next/navigation";
 import popToast from "@/components/common/toast";
 import { mypageTabs } from "@/constants/photographer/mypage";
 import { SERVICE_LINKS } from "@/constants/common/common";
+import { logout } from "@/services/client/core/auth";
 import MenuItem from "./menu-item";
 import { itemStyles } from "./sidebar.css";
 
@@ -16,6 +17,13 @@ const MenuList = ({ hasServiceLinks }: { hasServiceLinks?: boolean }) => {
   const router = useRouter();
   const [url, setUrl] = useState<string>("");
   const currentTab = usePathname().split("/").pop();
+
+  async function handleLogout() {
+    const redirect = await logout();
+    if (redirect) {
+      router.push(redirect);
+    }
+  }
 
   useEffect(() => {
     const localData = localStorage.getItem("url");
@@ -130,6 +138,7 @@ const MenuList = ({ hasServiceLinks }: { hasServiceLinks?: boolean }) => {
         )}
         <MenuItem
           name="로그아웃"
+          onClick={handleLogout}
           icon="/icons/logout.svg"
           className={itemStyles.button}
         />

--- a/src/services/client/core/auth.ts
+++ b/src/services/client/core/auth.ts
@@ -7,7 +7,6 @@ export const logout = async () => {
       localStorage.removeItem("url");
       return response.url;
     }
-    throw new Error();
   } catch {
     popToast("다시 시도해 주세요.", "로그아웃에 실패했습니다.");
   }

--- a/src/services/client/core/auth.ts
+++ b/src/services/client/core/auth.ts
@@ -7,6 +7,7 @@ export const logout = async () => {
       localStorage.removeItem("url");
       return response.url;
     }
+    throw new Error("no redirect url at logout response");
   } catch {
     popToast("다시 시도해 주세요.", "로그아웃에 실패했습니다.");
   }

--- a/src/services/client/core/index.ts
+++ b/src/services/client/core/index.ts
@@ -1,6 +1,6 @@
 import ky from "ky";
 import { beforeError } from "@/services/common";
-import { beforeRequest } from "./interceptor";
+import { beforeRequest, beforeRetry } from "./interceptor";
 
 const apiClient = ky
   .create({
@@ -8,11 +8,18 @@ const apiClient = ky
     credentials: "include",
     mode: "cors",
     cache: "no-store",
+    retry: {
+      limit: 3,
+      methods: ["get", "post", "put", "delete"],
+      statusCodes: [401],
+      backoffLimit: 1000,
+    },
   })
   .extend({
     hooks: {
       beforeRequest: [beforeRequest],
       beforeError: [beforeError],
+      beforeRetry: [beforeRetry],
     },
   });
 

--- a/src/services/client/core/interceptor.ts
+++ b/src/services/client/core/interceptor.ts
@@ -1,4 +1,4 @@
-import { BeforeRequestHook } from "ky";
+import { BeforeRequestHook, BeforeRetryHook, HTTPError } from "ky";
 import { setAuthorizationHeader } from "@/services/common";
 
 export const beforeRequest: BeforeRequestHook = async (request) => {
@@ -9,5 +9,16 @@ export const beforeRequest: BeforeRequestHook = async (request) => {
   }
   if (!request.headers.has("Content-Type")) {
     request.headers.set("Content-Type", "application/json");
+  }
+};
+
+export const beforeRetry: BeforeRetryHook = async ({ error }) => {
+  if (error instanceof HTTPError && error.response.status === 401) {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_DOMAIN}auth`, {
+      method: "PUT",
+    });
+    if (response.redirected) {
+      window.location.href = response.url;
+    }
   }
 };

--- a/src/services/common/index.ts
+++ b/src/services/common/index.ts
@@ -1,4 +1,3 @@
-import { redirect } from "next/navigation";
 import { BeforeErrorHook, HTTPError, KyRequest } from "ky";
 import * as Sentry from "@sentry/nextjs";
 import { CustomedError, getCustomedErrorMessage } from "./error";
@@ -36,14 +35,7 @@ async function getCustomedError(error: HTTPError) {
 }
 
 export const beforeError: BeforeErrorHook = async (error) => {
-  if (error.response.status === 401) {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_DOMAIN}auth`, {
-      method: "PUT",
-    });
-    if (response.redirected) {
-      redirect(response.url);
-    }
-  } else {
+  if (error.response.status !== 401) {
     Sentry.captureException(error);
   }
   const customedError = await getCustomedError(error);

--- a/src/services/server/core/auth.ts
+++ b/src/services/server/core/auth.ts
@@ -40,7 +40,7 @@ export const setTokens = (accessToken: string, refreshToken: string) => {
   });
 };
 
-export const reissueTokens = async () => {
+export const reissueTokens = async (callback?: () => Promise<any>) => {
   const refreshToken = getRefreshToken();
   if (!refreshToken) {
     throw new Error();
@@ -62,6 +62,9 @@ export const reissueTokens = async () => {
       } else {
         setTokens(newAccessToken, newRefreshToken);
       }
+      if (callback) {
+        callback();
+      }
     } else {
       throw new Error();
     }
@@ -80,7 +83,7 @@ export const logout = async () => {
   });
   if (response.status === 401) {
     try {
-      await reissueTokens();
+      await reissueTokens(logout);
     } catch {
       deleteTokens();
       redirect("/");

--- a/src/services/server/core/index.ts
+++ b/src/services/server/core/index.ts
@@ -1,6 +1,6 @@
 import ky from "ky";
 import { beforeError } from "@/services/common";
-import { beforeRequest } from "./interceptor";
+import { beforeRequest, beforeRetry } from "./interceptor";
 
 export const api = ky
   .create({
@@ -8,10 +8,17 @@ export const api = ky
     credentials: "include",
     mode: "cors",
     cache: "no-store",
+    retry: {
+      limit: 3,
+      methods: ["get", "post", "put", "delete"],
+      statusCodes: [401],
+      backoffLimit: 1000,
+    },
   })
   .extend({
     hooks: {
       beforeRequest: [beforeRequest],
       beforeError: [beforeError],
+      beforeRetry: [beforeRetry],
     },
   });

--- a/src/services/server/core/interceptor.ts
+++ b/src/services/server/core/interceptor.ts
@@ -1,4 +1,5 @@
-import { BeforeRequestHook } from "ky";
+import { BeforeRequestHook, BeforeRetryHook, HTTPError } from "ky";
+import { redirect } from "next/navigation";
 import { setAuthorizationHeader } from "@/services/common";
 import { getAccessToken } from "./auth";
 
@@ -7,5 +8,16 @@ export const beforeRequest: BeforeRequestHook = async (request) => {
   setAuthorizationHeader(request, accessToken);
   if (!request.headers.has("Content-Type")) {
     request.headers.set("Content-Type", "application/json");
+  }
+};
+
+export const beforeRetry: BeforeRetryHook = async ({ error }) => {
+  if (error instanceof HTTPError && error.response.status === 401) {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_DOMAIN}auth`, {
+      method: "PUT",
+    });
+    if (response.redirected) {
+      redirect(response.url);
+    }
   }
 };


### PR DESCRIPTION
## 체크리스트
- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 새로 추가된 사이드바에서 로그아웃 요청이 제대로 연결되어 있지 않아서 추가함
* 토큰 만료(401 에러 발생) 이후 처리 방식 보완

## 고민한 사항
* 기존에 토큰이 만료된 상태로 api 요청이 발생할 경우, 정상적으로 토큰이 재발급되고 쿠키에 저장된 토큰이 변경되었음에도 에러 메시지가 나타나고 한 번 새로고침을 해야 정상 동작하거나, (작가측의 경우) 새로고침했을 때 '/photographer' 페이지로 이동해 있는 현상 등이 있었습니다. 확인 결과 기존에 401 에러를 확인하고 토큰 재발급 요청을 보내는 로직이 'beforeError' 훅에 포함되어 있었는데, 해당 훅의 경우 에러를 호출 부분으로 던지기 전에 동작하기 때문에 api 재시도 이전에 동작하지 않는다는 것을 확인하고 'beforeRetry' 훅으로 분리했습니다. http 인스턴스를 공유하고 있지 않아 해당 훅을 적용받지 않는 로그아웃의 경우에도 retry 로직을 추가했습니다. 

(+ 로컬 환경에서 테스트했을 때, 발급 받은 토큰이 만료된 상태로 api 요청을 보낼시 401 실패 발생 > retry hook에서 토큰 재발급 > 쿠키에 저장된 토큰 변경됨 > 화면 단에서는 에러 발생 없이 요청 성공하는 것을 확인했습니다. 다만 한 번 테스트하려면 토큰을 발급 받고 30분이 지나 만료되기를 기다려야 하다 보니 많이 테스트해 보지는 못했는데 다른 테스트 방법이 있을지…! 🥲)

* 추가로 로컬 환경에서 로그아웃을 시도할 때 실패하는 문제가 있었는데, 해당 문제의 경우 api 요청 - 서버 사이드 로직 (쿠키에 저장한 토큰 삭제) 까지는 정상 동작했으나 localhost에서 www.freebe.co.kr 도메인으로 리다이렉트가 발생하면서 CORS 에러가 났던 것으로 파악했습니다. 리다이렉트 url의 도메인만 localhost로 변경해서 테스트 해 봤을 때 문제가 없었기 때문에, 별도로 로직을 수정하지는 않는 쪽을 생각 중입니다!

## 리뷰 요청사항
* 시급도: `높음`
* 크게는 없구 `services` 폴더만 한 번 훑어봐 주셔도 괜찮을 것 같습니당! `/client`, `/server` 각각 클라이언트 사이드, 서버 사이드에서 발생하는 api 요청을 포함하고 있고 토큰 관련 로직은 `/server/auth`, beforeRetry 훅은 각 폴더의 `/interceptor` 파일에 작성되어 있습니다.
