### PR TITLE
[FU-336] image file size

### DIFF
--- a/src/constants/common/common.ts
+++ b/src/constants/common/common.ts
@@ -9,8 +9,8 @@ export const IMAGE_STACK_SOURCES = [
 
 export const ACCEPTED_IMAGE = {
   file: ".jpeg,.jpg,.png,.bmp,.webp,.tiff,.tif,.ico,.svg",
-  info: "최대 10MB의 이미지 파일만 업로드 가능합니다.",
-  size: 1024 ** 2 * 10,
+  info: "최대 50MB의 이미지 파일만 업로드 가능합니다.",
+  size: 1024 ** 2 * 50,
 };
 
 export const SERVICE_LINKS = {

--- a/src/containers/photographer/product/form/index.tsx
+++ b/src/containers/photographer/product/form/index.tsx
@@ -222,7 +222,7 @@ const ProductForm = ({
             type="submit"
             styleType="primary"
             size="md"
-            title="저장하기"
+            title="등록하기"
             style={{ marginTop: 40 }}
           />
         )}

--- a/src/services/common/error.ts
+++ b/src/services/common/error.ts
@@ -13,6 +13,8 @@ export const CUSTOMED_CODE: { [key: string]: string } = {
 
 const CUSTOMED_STATUS: { [key: number]: string } = {
   404: "존재하지 않습니다.",
+  // TODO: 커스텀 코드로 처리
+  413: "이미지의 용량이 너무 큽니다.",
 };
 
 export function getCustomedErrorMessage(


### PR DESCRIPTION
## 체크리스트
- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- 413 payload too large 에러 커스텀 메시지 추가
- 이미지 최대 용량 50MB로 변경

## 고민한 사항
- https://github.com/SWM-15th-ForU/freebe-frontend/pull/71 에서 이미지 용량 초과와 관련한 에러 코드를 포함해 둔 상태라(` MAXIMUM_UPLOAD_SIZE_EXCEEDED`) 413 status에 대해서는 포괄적으로 안내하고 (ex. 요청의 크기가 너무 큽니다) 해당 에러 코드에 구체적인 이미지 관련 안내 메시지가 연결되어 있는 게 적합할 것 같았지만, 아직 해당 내용이 배포되지 않은 만큼 이미지 용량 초과 관련 에러 코드에서 사용했던 안내 메시지를 연결해 두었습니다. FU-324 티켓에서 정리 예정입니다.