### PR TITLE
[FU-337] mobile usability

### DIFF
--- a/src/containers/photographer/main/header.tsx
+++ b/src/containers/photographer/main/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { LinkType } from "profile-types";
@@ -23,6 +23,7 @@ const Header = ({
   links?: LinkType[];
 }) => {
   const router = useRouter();
+  const pathName = usePathname();
   const searchParams = useSearchParams();
   const [opened, { close, open }] = useDisclosure(false);
   const [isOnTutorial, { close: closeTutorial, open: openTutorial }] =
@@ -36,8 +37,14 @@ const Header = ({
     const tutorialParam = searchParams.get("tutorial");
     if (tutorialParam) {
       openTutorial();
+    } else {
+      closeTutorial();
     }
   }, [searchParams]);
+
+  useEffect(() => {
+    close();
+  }, [pathName]);
 
   return (
     <header className={styles.headerContainer}>

--- a/src/containers/photographer/mypage/profile/edit/banner.tsx
+++ b/src/containers/photographer/mypage/profile/edit/banner.tsx
@@ -1,12 +1,15 @@
 import { ChangeEvent } from "react";
 import { useFormContext } from "react-hook-form";
 import { PhotographerForm } from "profile-types";
+import BackgroundImage from "@/containers/customer/main/background-image";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import { ACCEPTED_IMAGE } from "@/constants/common/common";
 import { editStyles } from "./edit.css";
 
 const Banner = () => {
-  const { setValue } = useFormContext<PhotographerForm>();
+  const { setValue, watch } = useFormContext<PhotographerForm>();
+
+  const bannerImg = watch("bannerImg");
 
   function handleDeleteBanner() {
     setValue("bannerImg", undefined);
@@ -24,6 +27,11 @@ const Banner = () => {
   return (
     <div className={editStyles.box}>
       <span className={editStyles.title}>배너 이미지</span>
+      {bannerImg && (
+        <div className={editStyles.banner}>
+          <BackgroundImage mainImage={bannerImg?.url} />
+        </div>
+      )}
       <div className={editStyles.buttonsWrapper}>
         <CustomButton
           title="삭제"

--- a/src/containers/photographer/mypage/profile/edit/basic-info.tsx
+++ b/src/containers/photographer/mypage/profile/edit/basic-info.tsx
@@ -63,6 +63,7 @@ const BasicInfo = () => {
           formField="profileName"
           disabled
           container={{ marginTop: 0 }}
+          style={{ width: 150, minWidth: 0 }}
         />
         <TextInput<PhotographerForm>
           title="연락처"
@@ -70,6 +71,7 @@ const BasicInfo = () => {
           formField="contact"
           multiline
           container={{ marginBottom: 10 }}
+          style={{ width: 150, minWidth: 0 }}
         />
         <InfoCaption
           information="설정한 연락처는(전화번호, 카카오톡 채팅방 링크, 인스타그램 아이디
@@ -84,6 +86,7 @@ const BasicInfo = () => {
           formField="message"
           inputSize="md"
           multiline
+          style={{ width: 150, minWidth: 0 }}
         />
         {errors.message && (
           <span className={editStyles.error}>{errors.message.message}</span>

--- a/src/containers/photographer/mypage/profile/edit/edit.css.ts
+++ b/src/containers/photographer/mypage/profile/edit/edit.css.ts
@@ -33,6 +33,11 @@ export const linkStyles = styleVariants({
         outline: "none",
         borderBottomColor: "#007AFF",
       },
+      "@media": {
+        [breakpoints.mobile]: {
+          minWidth: 0,
+        },
+      },
     },
   ],
   error: [
@@ -78,6 +83,12 @@ export const editStyles = styleVariants({
     display: "flex",
     alignItems: "center",
     minWidth: "fit-content",
+    "@media": {
+      [breakpoints.mobile]: {
+        flexDirection: "column",
+        alignItems: "flex-start",
+      },
+    },
   },
   link: {
     paddingTop: 20,
@@ -91,6 +102,14 @@ export const editStyles = styleVariants({
     flex: "0 0 104px",
     marginRight: 20,
     gap: 12,
+    "@media": {
+      [breakpoints.mobile]: {
+        flexDirection: "row",
+        width: 300,
+        alignItems: "flex-end",
+        marginBottom: 30,
+      },
+    },
   },
   title: [texts["headline-03"], sprinkles({ color: "text-02" })],
   fieldsWrapper: {
@@ -115,6 +134,15 @@ export const editStyles = styleVariants({
     }),
     { margin: 3, display: "block" },
   ],
+  banner: {
+    margin: "20px 0px",
+    display: "none",
+    "@media": {
+      [breakpoints.mobile]: {
+        display: "block",
+      },
+    },
+  },
 });
 
 export const leaveStyles = styleVariants({


### PR DESCRIPTION
## 체크리스트
- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 모바일 사용성 개선
튜토리얼 종료 로직 보완
사이드 메뉴에서 페이지 이동시 메뉴 닫히도록 수정
프로필 편집 페이지 모바일 환경 최적화

## 고민한 사항
* 개발자 도구에서 반응형 테스트했을 때는 UI 깨지는 부분을 발견하지 못했었는데 사파리 / 크롬 환경으로 인해 차이가 생겼던 것 같습니다…! 🙄 이번에는 사파리 / 크롬에서 모바일 / PC 버전 각각 체크했습니다. 좌우 스크롤을 완전히 없애기는 어려움이 있어서, UI가 깨지는 부분이 없도록 수정하고 모바일 환경에서도 배너 이미지를 확인할 수 있도록 수정했습니다.

## 스크린샷
![FU-337](https://github.com/user-attachments/assets/e9442b6b-1d0c-4525-b182-4f346e5b4daf)


[FU-337]: https://for-u.atlassian.net/browse/FU-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ