### PR TITLE
[FU-341] request timeout

### DIFF
--- a/src/constants/common/common.ts
+++ b/src/constants/common/common.ts
@@ -9,8 +9,8 @@ export const IMAGE_STACK_SOURCES = [
 
 export const ACCEPTED_IMAGE = {
   file: ".jpeg,.jpg,.png,.bmp,.webp,.tiff,.tif,.ico,.svg",
-  info: "최대 50MB의 이미지 파일만 업로드 가능합니다.",
-  size: 1024 ** 2 * 50,
+  info: "최대 10MB의 이미지 파일만 업로드 가능합니다.",
+  size: 1024 ** 2 * 10,
 };
 
 export const SERVICE_LINKS = {

--- a/src/containers/customer/products/info.tsx
+++ b/src/containers/customer/products/info.tsx
@@ -72,7 +72,13 @@ const ProductInfo = ({
         {images.map((image, index) => {
           return (
             <Carousel.Slide key={index} className={infoStyles.slide}>
-              <Image src={image} alt="" fill style={{ objectFit: "cover" }} />
+              <Image
+                src={image}
+                alt=""
+                fill
+                style={{ objectFit: "cover" }}
+                sizes="450px"
+              />
             </Carousel.Slide>
           );
         })}

--- a/src/containers/photographer/product/form/field/image-input.tsx
+++ b/src/containers/photographer/product/form/field/image-input.tsx
@@ -61,6 +61,10 @@ const ImagesInput = ({ images, setImage, disabled }: ImageInputProps) => {
         return newImages.slice(ARRAY_START_INDEX, MAX_IMAGE_COUNT);
       });
     }
+    if (e.type === "change") {
+      const input = e.target as HTMLInputElement;
+      input.value = "";
+    }
   }
 
   function handleDeleteImage(deleteImageIndex: number) {

--- a/src/containers/photographer/product/form/field/image-input.tsx
+++ b/src/containers/photographer/product/form/field/image-input.tsx
@@ -5,7 +5,11 @@ import { useDisclosure } from "@mantine/hooks";
 import { ACCEPTED_IMAGE } from "@/constants/common/common";
 import InfoCaption from "@/components/common/info-caption";
 import ImageThumbnail from "@/components/images/image-thumbnail";
-import { validatingFiles } from "@/utils/image";
+import {
+  getFormImageFromFiles,
+  resizeImages,
+  validatingFiles,
+} from "@/utils/image";
 import {
   CustomButton,
   FinishButton,
@@ -43,23 +47,30 @@ const ImagesInput = ({ images, setImage, disabled }: ImageInputProps) => {
     return null;
   }
 
-  function handleAddImage(
+  async function handleAddImage(
     e: React.DragEvent | React.ChangeEvent<HTMLInputElement>,
   ) {
     e.preventDefault();
     const selectedFiles = getFileList(e);
-    const { isOver, selectedImages } = validatingFiles(selectedFiles);
+    const { isOver, validatedFiles } = validatingFiles(selectedFiles);
     if (isOver) {
       popToast("10MB 이하의 이미지만 등록할 수 있습니다.");
     }
-    if (selectedImages.length > 0) {
-      setImage((prev) => {
-        const newImages = [...prev, ...selectedImages];
-        if (newImages.length > MAX_IMAGE_COUNT) {
-          popToast("이미지는 최대 10개까지 등록할 수 있습니다.");
-        }
-        return newImages.slice(ARRAY_START_INDEX, MAX_IMAGE_COUNT);
-      });
+    if (validatedFiles.length > 0) {
+      try {
+        const resizedImages = await resizeImages(validatedFiles);
+        setImage((prev) => {
+          const newImages = [...prev, ...getFormImageFromFiles(resizedImages)];
+          console.log(newImages);
+          if (newImages.length > MAX_IMAGE_COUNT) {
+            popToast("이미지는 최대 10개까지 등록할 수 있습니다.");
+          }
+          return newImages.slice(ARRAY_START_INDEX, MAX_IMAGE_COUNT);
+        });
+        console.log(images);
+      } catch {
+        popToast("다시 시도해주세요.", "이미지 업로드에 실패했습니다.", true);
+      }
     }
     if (e.type === "change") {
       const input = e.target as HTMLInputElement;

--- a/src/services/client/photographer/products.ts
+++ b/src/services/client/photographer/products.ts
@@ -3,6 +3,8 @@ import { FilterItemType } from "common-types";
 import { PARAMETER_DEFAULT_RADIX } from "@/constants/common/common";
 import apiClient from "../core";
 
+const TIMEOUT_BOUND_FOR_IMAGE_REQUESTS = 20000;
+
 export async function getProductTitles(): Promise<FilterItemType[]> {
   const { data } = await apiClient.get("photographer/product/title").json<{
     data: {
@@ -64,6 +66,7 @@ export async function postNewProduct(
   await apiClient
     .post("photographer/product", {
       body: formData,
+      timeout: TIMEOUT_BOUND_FOR_IMAGE_REQUESTS,
     })
     .json();
 }
@@ -146,6 +149,7 @@ export async function putProductDetails(
 
   const response = await apiClient.put("photographer/product", {
     body: formData,
+    timeout: TIMEOUT_BOUND_FOR_IMAGE_REQUESTS,
   });
   return response;
 }

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -38,7 +38,7 @@ export function validatingFiles(inputFiles: FileList | null): {
 const MAX_WIDTH_UPLOAD = 1000;
 const MAX_HEIGHT_UPLOAD = 1000;
 
-async function resizeImage(file: File): Promise<File | null> {
+async function resizeImage(file: File): Promise<File> {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.src = URL.createObjectURL(file);
@@ -82,12 +82,10 @@ async function resizeImage(file: File): Promise<File | null> {
 }
 
 export async function resizeImages(files: File[]): Promise<File[]> {
-  const resizedFiles: File[] = [];
-
-  Promise.all(
+  const resizedFiles = await Promise.all(
     files.map(async (file) => {
-      const resizedFile = await resizeImage(file);
-      if (resizedFile) resizedFiles.push(resizedFile);
+      const resizedImage = await resizeImage(file);
+      return resizedImage;
     }),
   );
 

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -20,17 +20,68 @@ export function getFormImageFromFiles(files: File[]): FormImage[] {
 
 export function validatingFiles(inputFiles: FileList | null): {
   isOver: boolean;
-  selectedImages: FormImage[];
+  validatedFiles: File[];
 } {
   if (inputFiles === null) {
-    return { isOver: false, selectedImages: [] };
+    return { isOver: false, validatedFiles: [] };
   }
   const filesArray = Array.from(inputFiles);
   return {
     isOver:
       filesArray.filter((file) => file.size > ACCEPTED_IMAGE.size).length > 0,
-    selectedImages: getFormImageFromFiles(
-      filesArray.filter((file) => file.size <= ACCEPTED_IMAGE.size),
+    validatedFiles: filesArray.filter(
+      (file) => file.size <= ACCEPTED_IMAGE.size,
     ),
   };
+}
+
+const MAX_WIDTH_UPLOAD = 1000;
+const MAX_HEIGHT_UPLOAD = 1000;
+
+async function resizeImage(file: File): Promise<File | null> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.src = URL.createObjectURL(file);
+
+    img.onload = () => {
+      let targetWidth = img.width;
+      let targetHeight = img.height;
+
+      if (targetWidth > MAX_WIDTH_UPLOAD) {
+        targetHeight *= MAX_WIDTH_UPLOAD / targetWidth;
+        targetWidth = MAX_WIDTH_UPLOAD;
+      }
+      if (targetHeight > MAX_HEIGHT_UPLOAD) {
+        targetWidth *= MAX_HEIGHT_UPLOAD / targetHeight;
+        targetHeight = MAX_HEIGHT_UPLOAD;
+      }
+      const canvas = document.createElement("canvas");
+      canvas.width = targetWidth;
+      canvas.height = targetHeight;
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return reject(new Error("failed to use canvas"));
+
+      ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+
+      canvas.toBlob((blob) => {
+        if (!blob) return reject(new Error("failed to extract blob"));
+        const resizedFile = new File([blob], file.name, { type: file.type });
+        resolve(resizedFile);
+      }, file.type);
+    };
+
+    img.onerror = () => reject(new Error("failed to load image"));
+  });
+}
+
+export async function resizeImages(files: File[]): Promise<File[]> {
+  const resizedFiles: File[] = [];
+
+  files.map(async (file) => {
+    const resizedFile = await resizeImage(file);
+    if (resizedFile) resizedFiles.push(resizedFile);
+  });
+
+  return resizedFiles;
 }

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -47,6 +47,12 @@ async function resizeImage(file: File): Promise<File | null> {
       let targetWidth = img.width;
       let targetHeight = img.height;
 
+      if (
+        targetHeight <= MAX_HEIGHT_UPLOAD &&
+        targetWidth <= MAX_WIDTH_UPLOAD
+      ) {
+        resolve(file);
+      }
       if (targetWidth > MAX_WIDTH_UPLOAD) {
         targetHeight *= MAX_WIDTH_UPLOAD / targetWidth;
         targetWidth = MAX_WIDTH_UPLOAD;
@@ -78,10 +84,12 @@ async function resizeImage(file: File): Promise<File | null> {
 export async function resizeImages(files: File[]): Promise<File[]> {
   const resizedFiles: File[] = [];
 
-  files.map(async (file) => {
-    const resizedFile = await resizeImage(file);
-    if (resizedFile) resizedFiles.push(resizedFile);
-  });
+  Promise.all(
+    files.map(async (file) => {
+      const resizedFile = await resizeImage(file);
+      if (resizedFile) resizedFiles.push(resizedFile);
+    }),
+  );
 
   return resizedFiles;
 }


### PR DESCRIPTION
## 체크리스트
- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 상품 등록 / 수정시 이미지 전송 관련 최적화
* http 통신에 대한 timeout 옵션 수정
* 이미지 업로드 후 input value 초기화

## 고민한 사항
* 서버에서 상품이 정상적으로 등록되었음에도 화면상에서 실패 메시지가 발생하는 현상의 경우, http instance에 세팅되어 있는 timeout(디폴트 10s)이 문제가 되었던 것으로 추정하였습니다. 타임아웃이 발생하기 전 서버로 요청 자체는 전달되었으나, 요청이 처리되는 사이 10초가 지나 클라이언트에서는 타임아웃으로 처리되었고 서버에서는 들어온 요청을 마저 수행함으로써 해당 현상이 나타났을 것으로 추측됩니다. 

* 이미지 업로드로 인해 처리 시간이 길어질 수 있는 상품 등록 및 수정 요청에서 timeout을 20초로 늘렸습니다.

* 서버와 통신할 때 주고받는 이미지의 크기를 조절하기 위해 업로드 시점에 리사이징 로직을 추가했습니다. 너비 / 높이가 최대 1000px을 넘지 않게 제한하였고 개발 서버로 테스트한 결과는 다음과 같았습니다.

#### (a) 고용량 이미지 활용
- 리사이징 없이 원본 전송
파일 사이즈 각 6268505 (총 5장)
응답 시간 10.79초
- 리사이징 후 전송
파일 사이즈 200295 (총 5장)
응답 시간 1.44초

#### (b) 일반 이미지 활용
- 리사이징 없이 원본 전송
파일 사이즈 3578994 / 2357104 / 2397193 (총 3장)
응답 시간 4.87초
- 리사이징 후 전송
파일 사이즈 365144 / 281193 / 279028 (총 3장)
응답 시간 1.14초

눈으로 보기에 큰 차이가 없기는 했지만, 이미지 품질에 약간은 영향을 미치는 것 같고 개발 서버와 연결 상태가 일정하지 않았어서 (테스트 중간에 연결 문제로 실패가 몇 번 발생했습니다…!) 개발 서버 배포 이후 추가로 테스트해서 업데이트할지 결정하면 좋을 것 같습니다!

## 리뷰 요청사항
* 시급도: `보통`
* `src/containers/photographer/product/form/field/image-input.tsx`: 이미지 입력 이벤트 처리
* `src/utils/image.ts`: 이미지 리사이징 함수