### PR TITLE
[FU-342] disallow retry at login request

### DIFF
--- a/src/services/server/core/index.ts
+++ b/src/services/server/core/index.ts
@@ -10,7 +10,7 @@ export const api = ky
     cache: "no-store",
     retry: {
       limit: 3,
-      methods: ["get", "post", "put", "delete"],
+      methods: ["get"],
       statusCodes: [401],
       backoffLimit: 1000,
     },

--- a/src/services/server/login.ts
+++ b/src/services/server/login.ts
@@ -49,7 +49,9 @@ export async function login(
 
   const response = await api.post("login", {
     json: { roleType: roleType.toUpperCase(), code },
-    hooks: { beforeError: [handleLoginError] },
+    hooks: {
+      beforeError: [handleLoginError],
+    },
     cache: "no-store",
   });
 


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 로그인 요청에 대한 retry 차단

## 고민한 사항
* retry는 토큰 만료시 자동으로 재발급 시도 후 재시도하기 위한 목적으로만 쓰고 있었기 때문에, 기존에 retry 허용 status를 401으로 제한했음에도 해당 문제가 발생하였습니다. 센트리를 통해 에러 로그 검토해 보았을 때 다른 POST 요청 등에서는 재현되지 않고 있었기에, 서버 사이드 - 클라이언트 사이드 간의 차이가 해당 문제에 영향을 미칠 수 있을 것으로 보였습니다. 현재 서버 사이드에서 보내는 api 요청은 거의 데이터 페칭이기에, (인증 인가 처리 관련해서만 서버에서 요청을 보내는 경우가 생깁니다.) retry 허용 method를 GET으로 제한한 상태에서 테스트 결과 해당 문제 발생하지 않았습니다.