### PR TITLE
[FU-345] base schedule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6414,9 +6414,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
         "@types/crypto-js": "^4.2.2",
+        "@types/luxon": "^3.4.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -4990,6 +4991,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9950,9 +9958,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "dayjs": "^1.11.12",
         "embla-carousel-react": "^7.1.0",
         "ky": "^1.5.0",
+        "luxon": "^3.5.0",
         "next": "^14.2.12",
         "react": "^18",
         "react-dom": "^18",
@@ -9788,6 +9789,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dayjs": "^1.11.12",
     "embla-carousel-react": "^7.1.0",
     "ky": "^1.5.0",
+    "luxon": "^3.5.0",
     "next": "^14.2.12",
     "react": "^18",
     "react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",
     "@types/crypto-js": "^4.2.2",
+    "@types/luxon": "^3.4.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/photographer/(auth)/(layout)/mypage/schedule/page.tsx
+++ b/src/app/photographer/(auth)/(layout)/mypage/schedule/page.tsx
@@ -1,7 +1,22 @@
-import Preparing from "@/containers/ui/preparing";
+import PhotographerSchedule from "@/containers/photographer/mypage/schedule";
+import MypageLayout from "@/containers/ui/mypage-layout";
+import {
+  getCurrentBaseSchedule,
+  getCurrentUnit,
+} from "@/services/server/photographer/mypage/schedule";
 
-const MySchedulePage = () => {
-  return <Preparing />;
+const MySchedulePage = async () => {
+  const currentSchedule = await getCurrentBaseSchedule();
+  const currentUnit = await getCurrentUnit();
+
+  return (
+    <MypageLayout title="예약 일정 오픈">
+      <PhotographerSchedule
+        currentSchedule={currentSchedule}
+        unit={currentUnit}
+      />
+    </MypageLayout>
+  );
 };
 
 export default MySchedulePage;

--- a/src/components/inputs/input.css.ts
+++ b/src/components/inputs/input.css.ts
@@ -2,6 +2,38 @@ import sprinkles from "@/styles/sprinkles.css";
 import { texts } from "@/styles/text.css";
 import { style, styleVariants } from "@vanilla-extract/css";
 
+export const timeSelectorStyles = styleVariants({
+  container: [
+    sprinkles({
+      backgroundColor: "white",
+      borderColor: "stroke-grey",
+      color: "text-01",
+    }),
+    texts["body-01"],
+    {
+      position: "relative",
+      borderRadius: 8,
+      borderWidth: 1,
+      borderStyle: "solid",
+      padding: "8px 18px",
+    },
+  ],
+  dropdown: [
+    sprinkles({ borderColor: "stroke-grey" }),
+    {
+      padding: "8px 0px 8px 8px",
+      borderWidth: 1,
+      borderStyle: "solid",
+      borderRadius: 8,
+      boxShadow: "0px 10px 25px 0px #00000026",
+      display: "flex",
+      maxHeight: 180,
+    },
+  ],
+  list: { overflowY: "scroll", padding: 0 },
+  selectedValue: [sprinkles({ backgroundColor: "blue", color: "white" })],
+});
+
 const baseCheckbox = style({
   borderRadius: 4,
   height: 24,

--- a/src/components/inputs/input.css.ts
+++ b/src/components/inputs/input.css.ts
@@ -11,6 +11,7 @@ export const timeSelectorStyles = styleVariants({
     }),
     texts["body-01"],
     {
+      width: 90,
       position: "relative",
       borderRadius: 8,
       borderWidth: 1,

--- a/src/components/inputs/time-selector.tsx
+++ b/src/components/inputs/time-selector.tsx
@@ -52,7 +52,7 @@ const TimeSelector = ({
   }
 
   return (
-    <Menu withArrow position="bottom">
+    <Menu closeOnItemClick={false} withArrow position="bottom">
       <Menu.Target>
         <button className={timeSelectorStyles.container} type="button">
           {timeValue.toFormat("HH:mm")}
@@ -94,7 +94,7 @@ const TimeSelector = ({
                         : undefined
                     }
                   >
-                    <span>{minute}</span>
+                    <span>{minute === 0 ? "00" : minute}</span>
                   </Menu.Item>
                 ))}
             </div>

--- a/src/components/inputs/time-selector.tsx
+++ b/src/components/inputs/time-selector.tsx
@@ -1,0 +1,108 @@
+import { DateTime } from "luxon";
+import { TimeUnitType } from "calender-types";
+import { Menu } from "@mantine/core";
+import { timeSelectorStyles } from "./input.css";
+
+const TimeSelector = ({
+  time,
+  setTime,
+  minTime,
+  maxTime,
+  unit,
+}: {
+  time: string;
+  setTime: (newTime: string) => void;
+  minTime?: string;
+  maxTime?: string;
+  unit: TimeUnitType;
+}) => {
+  const hours = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 23,
+  ];
+  const minutes = [0, 30];
+  const timeValue = DateTime.fromFormat(time, "HH:mm:ss");
+
+  function setHour(hour: number) {
+    const newTimeValue = timeValue.set({ hour });
+    setTime(newTimeValue.toFormat("HH:mm:ss"));
+  }
+
+  function setMinute(minute: number) {
+    const newTimeValue = timeValue.set({ minute });
+    setTime(newTimeValue.toFormat("HH:mm:ss"));
+  }
+
+  function checkAbility(hour: number, minute: number) {
+    return (
+      (!minTime ||
+        DateTime.fromObject({ hour, minute }) >
+          DateTime.fromFormat(minTime, "HH:mm:ss")) &&
+      (!maxTime ||
+        DateTime.fromObject({ hour, minute }) <
+          DateTime.fromFormat(maxTime, "HH:mm:ss"))
+    );
+  }
+
+  function formatHour(hour: number) {
+    const hourValue = DateTime.fromObject({ hour, minute: 0 });
+    return unit === "SIXTY_MINUTES"
+      ? hourValue.toFormat("HH:mm")
+      : hourValue.toFormat("HH");
+  }
+
+  return (
+    <Menu withArrow position="bottom">
+      <Menu.Target>
+        <button className={timeSelectorStyles.container} type="button">
+          {timeValue.toFormat("HH:mm")}
+        </button>
+      </Menu.Target>
+      <Menu.Dropdown className={timeSelectorStyles.dropdown}>
+        <div className={timeSelectorStyles.list}>
+          <div>
+            {hours
+              .filter((hour) => checkAbility(hour, timeValue.minute))
+              .map((hour) => (
+                <Menu.Item
+                  key={hour}
+                  autoFocus={hour === timeValue.hour}
+                  onClick={() => setHour(hour)}
+                  className={
+                    hour === timeValue.hour
+                      ? timeSelectorStyles.selectedValue
+                      : undefined
+                  }
+                >
+                  <span>{formatHour(hour)}</span>
+                </Menu.Item>
+              ))}
+          </div>
+        </div>
+        {unit === "THIRTY_MINUTES" && (
+          <div className={timeSelectorStyles.list}>
+            <div>
+              {minutes
+                .filter((minute) => checkAbility(timeValue.hour, minute))
+                .map((minute) => (
+                  <Menu.Item
+                    key={minute}
+                    onClick={() => setMinute(minute)}
+                    className={
+                      minute === timeValue.minute
+                        ? timeSelectorStyles.selectedValue
+                        : undefined
+                    }
+                  >
+                    <span>{minute}</span>
+                  </Menu.Item>
+                ))}
+            </div>
+          </div>
+        )}
+      </Menu.Dropdown>
+    </Menu>
+  );
+};
+
+export default TimeSelector;

--- a/src/constants/schedule.ts
+++ b/src/constants/schedule.ts
@@ -1,0 +1,11 @@
+import { DaysType } from "calender-types";
+
+export const dayNames: { [key in DaysType]: string } = {
+  MONDAY: "월",
+  TUESDAY: "화",
+  WEDNESDAY: "수",
+  THURSDAY: "목",
+  FRIDAY: "금",
+  SATURDAY: "토",
+  SUNDAY: "일",
+};

--- a/src/constants/schedule.ts
+++ b/src/constants/schedule.ts
@@ -1,5 +1,15 @@
 import { DaysType } from "calender-types";
 
+export const daysArray: DaysType[] = [
+  "MONDAY",
+  "TUESDAY",
+  "WEDNESDAY",
+  "THURSDAY",
+  "FRIDAY",
+  "SATURDAY",
+  "SUNDAY",
+];
+
 export const dayNames: { [key in DaysType]: string } = {
   MONDAY: "월",
   TUESDAY: "화",

--- a/src/containers/photographer/mypage/schedule/base/base.css.ts
+++ b/src/containers/photographer/mypage/schedule/base/base.css.ts
@@ -1,0 +1,47 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+import sprinkles from "@/styles/sprinkles.css";
+import { texts } from "@/styles/text.css";
+
+const baseIcon = style({
+  transition: "transform 0.5s ease",
+  paddingLeft: 3,
+});
+
+export const baseScheduleStyles = styleVariants({
+  control: [
+    {
+      border: "none",
+      background: "none",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+  ],
+  openIcon: [baseIcon, { transform: "rotate(90deg)" }],
+  closeIcon: [baseIcon, { transform: "rotate(270deg)" }],
+});
+
+export const dayScheduleStyles = styleVariants({
+  container: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    rowGap: 12,
+    justifyContent: "space-between",
+  },
+  timeWrapper: [
+    sprinkles({ color: "text-02" }),
+    texts["headline-03"],
+    {
+      display: "flex",
+      flexWrap: "wrap",
+      alignItems: "center",
+      gap: 8,
+    },
+  ],
+  value: [
+    sprinkles({ color: "text-02" }),
+    texts["headline-03"],
+    { padding: "0px 16px" },
+  ],
+});

--- a/src/containers/photographer/mypage/schedule/base/base.css.ts
+++ b/src/containers/photographer/mypage/schedule/base/base.css.ts
@@ -7,6 +7,28 @@ const baseIcon = style({
   paddingLeft: 3,
 });
 
+export const confirmModalStyles = styleVariants({
+  caption: [texts["body-02"], sprinkles({ color: "text-02" })],
+  content: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+    margin: "16px 0px 40px 0px",
+  },
+  schedule: {
+    display: "flex",
+    gap: 40,
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  inner: {
+    left: 0,
+    right: 0,
+  },
+  key: [texts["headline-03"], sprinkles({ color: "blue" })],
+  value: [texts["body-02"], sprinkles({ color: "text-01" })],
+});
+
 export const baseScheduleStyles = styleVariants({
   control: [
     {

--- a/src/containers/photographer/mypage/schedule/base/confirm-modal.tsx
+++ b/src/containers/photographer/mypage/schedule/base/confirm-modal.tsx
@@ -1,0 +1,67 @@
+import { BaseScheduleForm } from "calender-types";
+import { useFormContext } from "react-hook-form";
+import { Modal } from "@mantine/core";
+import { CustomButton } from "@/components/buttons/common-buttons";
+import { commonModalStyles } from "@/styles/mantine.css";
+import { dayNames, daysArray } from "@/constants/schedule";
+import { formatTimeString } from "@/utils/date";
+import { confirmModalStyles } from "./base.css";
+
+const ConfirmModal = ({
+  opened,
+  close,
+}: {
+  opened: boolean;
+  close: () => void;
+}) => {
+  const {
+    getValues,
+    formState: { isSubmitting },
+  } = useFormContext<BaseScheduleForm>();
+
+  const form = getValues();
+
+  return (
+    <Modal
+      onClose={close}
+      opened={opened}
+      centered
+      size="lg"
+      title="변경 전 확인해주세요."
+      withinPortal={false}
+      classNames={{ ...commonModalStyles, inner: confirmModalStyles.inner }}
+    >
+      <span className={confirmModalStyles.caption}>
+        변경한 스케줄은 예약하려는 고객에게 바로 공유돼요. 단, 이미 신청된
+        예약에서 고객이 설정한 희망 시간과 확정된 예약의 촬영 시간은 스케줄
+        변경에 영향을 받지 않아요.
+      </span>
+      <div className={confirmModalStyles.content}>
+        {daysArray.map((day) => (
+          <div key={day} className={confirmModalStyles.schedule}>
+            <span className={confirmModalStyles.key}>{dayNames[day]}</span>
+            <div className={confirmModalStyles.value}>
+              {form[day].isOff ? (
+                <span>휴무일</span>
+              ) : (
+                <div>
+                  <span>{formatTimeString(form[day].startTime)} ~ </span>
+                  <span>{formatTimeString(form[day].endTime)}</span>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <CustomButton
+        type="submit"
+        title="위 스케줄로 변경하기"
+        size="sm"
+        styleType="primary"
+        loading={isSubmitting}
+      />
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/src/containers/photographer/mypage/schedule/base/day-schedule.tsx
+++ b/src/containers/photographer/mypage/schedule/base/day-schedule.tsx
@@ -1,0 +1,53 @@
+import { useFormContext } from "react-hook-form";
+import { BasicScheduleForm, DaysType, TimeUnitType } from "calender-types";
+import Chip from "@/components/common/chip";
+import TimeSelector from "@/components/inputs/time-selector";
+import { dayNames } from "@/constants/schedule";
+import { dayScheduleStyles } from "./base.css";
+
+const DaySchedule = ({ day, unit }: { day: DaysType; unit: TimeUnitType }) => {
+  const { watch, setValue } = useFormContext<BasicScheduleForm>();
+  const { startTime, endTime, isOff } = watch(day);
+
+  function setNewTime(newTime: string, type: "startTime" | "endTime") {
+    setValue(`${day}.${type}`, newTime);
+  }
+
+  function toggleOff() {
+    setValue(`${day}.isOff`, !isOff);
+  }
+
+  return (
+    <div className={dayScheduleStyles.container}>
+      <Chip
+        name={dayNames[day]}
+        onClick={toggleOff}
+        selected={!isOff}
+        container={{ height: 40 }}
+      />
+      {isOff ? (
+        <span className={dayScheduleStyles.value}>휴무일</span>
+      ) : (
+        <div className={dayScheduleStyles.timeWrapper}>
+          <span>시작 시간</span>
+          <TimeSelector
+            time={startTime}
+            setTime={(newTime) => setNewTime(newTime, "startTime")}
+            maxTime={endTime}
+            unit={unit}
+          />
+          <span>~</span>
+          <span>종료 시간</span>
+          <TimeSelector
+            time={endTime}
+            setTime={(newTime) => setNewTime(newTime, "endTime")}
+            minTime={startTime}
+            unit={unit}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DaySchedule;

--- a/src/containers/photographer/mypage/schedule/base/day-schedule.tsx
+++ b/src/containers/photographer/mypage/schedule/base/day-schedule.tsx
@@ -1,12 +1,12 @@
 import { useFormContext } from "react-hook-form";
-import { BasicScheduleForm, DaysType, TimeUnitType } from "calender-types";
+import { BaseScheduleForm, DaysType, TimeUnitType } from "calender-types";
 import Chip from "@/components/common/chip";
 import TimeSelector from "@/components/inputs/time-selector";
 import { dayNames } from "@/constants/schedule";
 import { dayScheduleStyles } from "./base.css";
 
 const DaySchedule = ({ day, unit }: { day: DaysType; unit: TimeUnitType }) => {
-  const { watch, setValue } = useFormContext<BasicScheduleForm>();
+  const { watch, setValue } = useFormContext<BaseScheduleForm>();
   const { startTime, endTime, isOff } = watch(day);
 
   function setNewTime(newTime: string, type: "startTime" | "endTime") {

--- a/src/containers/photographer/mypage/schedule/base/index.tsx
+++ b/src/containers/photographer/mypage/schedule/base/index.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Image from "next/image";
+import { FormProvider, useForm } from "react-hook-form";
+import { BasicScheduleForm, DaysType, TimeUnitType } from "calender-types";
+import { Collapse } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { CustomButton } from "@/components/buttons/common-buttons";
+import popToast from "@/components/common/toast";
+import { responseHandler } from "@/services/common/error";
+import { putNewBaseSchedule } from "@/services/client/photographer/mypage/schedule";
+import { scheduleStyles } from "../schedule.css";
+import DaySchedule from "./day-schedule";
+import { baseScheduleStyles } from "./base.css";
+
+const BasicSchedule = ({
+  unit,
+  currentSchedule,
+}: {
+  unit: TimeUnitType;
+  currentSchedule: BasicScheduleForm;
+}) => {
+  const [opened, { toggle }] = useDisclosure(false);
+  const method = useForm<BasicScheduleForm>({
+    defaultValues: currentSchedule,
+  });
+  const {
+    handleSubmit,
+    formState: { isSubmitting },
+  } = method;
+
+  const onSubmit = async (form: BasicScheduleForm) => {
+    responseHandler(
+      putNewBaseSchedule(form),
+      () => popToast("저장이 완료되었습니다."),
+      () => {
+        popToast("다시 시도해주세요.", "저장에 실패했습니다.", true);
+      },
+    );
+  };
+
+  const daysArray: DaysType[] = [
+    "MONDAY",
+    "TUESDAY",
+    "WEDNESDAY",
+    "THURSDAY",
+    "FRIDAY",
+    "SATURDAY",
+    "SUNDAY",
+  ];
+
+  return (
+    <div>
+      <FormProvider {...method}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className={scheduleStyles.head}>
+            <span className={scheduleStyles.title}>기본 스케줄</span>
+            <button
+              type="button"
+              onClick={toggle}
+              className={baseScheduleStyles.control}
+            >
+              <Image
+                src="/icons/right.svg"
+                alt="메뉴"
+                width={16}
+                height={16}
+                className={
+                  opened
+                    ? baseScheduleStyles.closeIcon
+                    : baseScheduleStyles.openIcon
+                }
+              />
+            </button>
+          </div>
+          <Collapse in={opened}>
+            <div className={scheduleStyles.body}>
+              {daysArray.map((day) => (
+                <DaySchedule day={day} unit={unit} key={day} />
+              ))}
+            </div>
+            <CustomButton
+              type="submit"
+              title="저장하기"
+              size="sm"
+              styleType="primary"
+              style={{ maxWidth: 600, margin: "24px auto 0px" }}
+              loading={isSubmitting}
+            />
+          </Collapse>
+        </form>
+      </FormProvider>
+    </div>
+  );
+};
+
+export default BasicSchedule;

--- a/src/containers/photographer/mypage/schedule/base/index.tsx
+++ b/src/containers/photographer/mypage/schedule/base/index.tsx
@@ -2,9 +2,10 @@
 
 import Image from "next/image";
 import { FormProvider, useForm } from "react-hook-form";
-import { BaseScheduleForm, DaysType, TimeUnitType } from "calender-types";
+import { BaseScheduleForm, TimeUnitType } from "calender-types";
 import { Collapse } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { daysArray } from "@/constants/schedule";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import popToast from "@/components/common/toast";
 import { responseHandler } from "@/services/common/error";
@@ -12,6 +13,7 @@ import { putNewBaseSchedule } from "@/services/client/photographer/mypage/schedu
 import { scheduleStyles } from "../schedule.css";
 import DaySchedule from "./day-schedule";
 import { baseScheduleStyles } from "./base.css";
+import ConfirmModal from "./confirm-modal";
 
 const BaseSchedule = ({
   unit,
@@ -21,13 +23,12 @@ const BaseSchedule = ({
   currentSchedule: BaseScheduleForm;
 }) => {
   const [opened, { toggle }] = useDisclosure(false);
+  const [requested, { open: request, close: cancelRequest }] =
+    useDisclosure(false);
   const method = useForm<BaseScheduleForm>({
     defaultValues: currentSchedule,
   });
-  const {
-    handleSubmit,
-    formState: { isSubmitting },
-  } = method;
+  const { handleSubmit } = method;
 
   const onSubmit = async (form: BaseScheduleForm) => {
     responseHandler(
@@ -37,17 +38,8 @@ const BaseSchedule = ({
         popToast("다시 시도해주세요.", "저장에 실패했습니다.", true);
       },
     );
+    cancelRequest();
   };
-
-  const daysArray: DaysType[] = [
-    "MONDAY",
-    "TUESDAY",
-    "WEDNESDAY",
-    "THURSDAY",
-    "FRIDAY",
-    "SATURDAY",
-    "SUNDAY",
-  ];
 
   return (
     <div>
@@ -80,13 +72,14 @@ const BaseSchedule = ({
               ))}
             </div>
             <CustomButton
-              type="submit"
+              type="button"
               title="저장하기"
               size="sm"
               styleType="primary"
               style={{ maxWidth: 600, margin: "24px auto 0px" }}
-              loading={isSubmitting}
+              onClick={request}
             />
+            <ConfirmModal opened={requested} close={cancelRequest} />
           </Collapse>
         </form>
       </FormProvider>

--- a/src/containers/photographer/mypage/schedule/base/index.tsx
+++ b/src/containers/photographer/mypage/schedule/base/index.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { FormProvider, useForm } from "react-hook-form";
-import { BasicScheduleForm, DaysType, TimeUnitType } from "calender-types";
+import { BaseScheduleForm, DaysType, TimeUnitType } from "calender-types";
 import { Collapse } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { CustomButton } from "@/components/buttons/common-buttons";
@@ -13,15 +13,15 @@ import { scheduleStyles } from "../schedule.css";
 import DaySchedule from "./day-schedule";
 import { baseScheduleStyles } from "./base.css";
 
-const BasicSchedule = ({
+const BaseSchedule = ({
   unit,
   currentSchedule,
 }: {
   unit: TimeUnitType;
-  currentSchedule: BasicScheduleForm;
+  currentSchedule: BaseScheduleForm;
 }) => {
   const [opened, { toggle }] = useDisclosure(false);
-  const method = useForm<BasicScheduleForm>({
+  const method = useForm<BaseScheduleForm>({
     defaultValues: currentSchedule,
   });
   const {
@@ -29,7 +29,7 @@ const BasicSchedule = ({
     formState: { isSubmitting },
   } = method;
 
-  const onSubmit = async (form: BasicScheduleForm) => {
+  const onSubmit = async (form: BaseScheduleForm) => {
     responseHandler(
       putNewBaseSchedule(form),
       () => popToast("저장이 완료되었습니다."),
@@ -94,4 +94,4 @@ const BasicSchedule = ({
   );
 };
 
-export default BasicSchedule;
+export default BaseSchedule;

--- a/src/containers/photographer/mypage/schedule/base/index.tsx
+++ b/src/containers/photographer/mypage/schedule/base/index.tsx
@@ -7,6 +7,7 @@ import { Collapse } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { daysArray } from "@/constants/schedule";
 import { CustomButton } from "@/components/buttons/common-buttons";
+import InfoCaption from "@/components/common/info-caption";
 import popToast from "@/components/common/toast";
 import { responseHandler } from "@/services/common/error";
 import { putNewBaseSchedule } from "@/services/client/photographer/mypage/schedule";
@@ -67,6 +68,7 @@ const BaseSchedule = ({
           </div>
           <Collapse in={opened}>
             <div className={scheduleStyles.body}>
+              <InfoCaption information="각 요일을 클릭해 휴무일로 변경할 수 있습니다." />
               {daysArray.map((day) => (
                 <DaySchedule day={day} unit={unit} key={day} />
               ))}

--- a/src/containers/photographer/mypage/schedule/index.tsx
+++ b/src/containers/photographer/mypage/schedule/index.tsx
@@ -1,0 +1,25 @@
+import { TimeUnitType } from "calender-types";
+import { Divider } from "@mantine/core";
+import BasicSchedule from "./base";
+import TimeBlock from "./time-block";
+import { scheduleStyles } from "./schedule.css";
+
+const PhotographerSchedule = ({
+  unit,
+  currentSchedule,
+}: {
+  unit: TimeUnitType;
+  currentSchedule: any;
+}) => {
+  return (
+    <div className={scheduleStyles.container}>
+      <TimeBlock currentUnit={unit} />
+      <Divider />
+      <BasicSchedule unit={unit} currentSchedule={currentSchedule} />
+      <Divider />
+      <div>날짜별 스케줄</div>
+    </div>
+  );
+};
+
+export default PhotographerSchedule;

--- a/src/containers/photographer/mypage/schedule/index.tsx
+++ b/src/containers/photographer/mypage/schedule/index.tsx
@@ -1,6 +1,6 @@
 import { TimeUnitType } from "calender-types";
 import { Divider } from "@mantine/core";
-import BasicSchedule from "./base";
+import BaseSchedule from "./base";
 import TimeBlock from "./time-block";
 import { scheduleStyles } from "./schedule.css";
 
@@ -15,7 +15,7 @@ const PhotographerSchedule = ({
     <div className={scheduleStyles.container}>
       <TimeBlock currentUnit={unit} />
       <Divider />
-      <BasicSchedule unit={unit} currentSchedule={currentSchedule} />
+      <BaseSchedule unit={unit} currentSchedule={currentSchedule} />
       <Divider />
       <div>날짜별 스케줄</div>
     </div>

--- a/src/containers/photographer/mypage/schedule/schedule.css.ts
+++ b/src/containers/photographer/mypage/schedule/schedule.css.ts
@@ -1,0 +1,45 @@
+import sprinkles from "@/styles/sprinkles.css";
+import { texts } from "@/styles/text.css";
+import { styleVariants } from "@vanilla-extract/css";
+
+export const scheduleStyles = styleVariants({
+  container: [
+    sprinkles({ backgroundColor: "white" }),
+    {
+      marginTop: 20,
+      borderRadius: 16,
+      padding: 24,
+      display: "flex",
+      flexDirection: "column",
+      gap: 20,
+    },
+  ],
+  head: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  title: [sprinkles({ color: "text-02" }), texts["headline-02"]],
+  body: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
+    paddingTop: 16,
+    gap: 16,
+    columnGap: 30,
+  },
+});
+
+export const timeblockStyles = styleVariants({
+  container: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  wrapper: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 8,
+    alignItems: "center",
+  },
+  text: [sprinkles({ color: "text-02" }), texts["headline-03"]],
+});

--- a/src/containers/photographer/mypage/schedule/time-block/confirm-modal.tsx
+++ b/src/containers/photographer/mypage/schedule/time-block/confirm-modal.tsx
@@ -14,47 +14,42 @@ const introduction: { [keys in TimeUnitType]: string } = {
 };
 
 const ConfirmModal = ({
-  onClose,
+  opened,
+  close,
   requestedUnit,
 }: {
-  onClose: () => void;
-  requestedUnit: null | TimeUnitType;
+  opened: boolean;
+  close: () => void;
+  requestedUnit: TimeUnitType;
 }) => {
   async function handleChangeUnit() {
-    if (requestedUnit) {
-      await responseHandler(
-        putNewUnit(requestedUnit),
-        () => {
-          onClose();
-          popToast("변경이 완료되었습니다.");
-        },
-        () => {
-          popToast("다시 시도해주세요.", "변경에 실패했습니다.", true);
-        },
-      );
-    }
+    await responseHandler(
+      putNewUnit(requestedUnit),
+      () => {
+        close();
+        popToast("변경이 완료되었습니다.");
+      },
+      () => {
+        popToast("다시 시도해주세요.", "변경에 실패했습니다.", true);
+      },
+    );
   }
 
   return (
     <Modal
-      onClose={onClose}
-      opened={requestedUnit !== null}
+      onClose={close}
+      opened={opened}
       centered
       title="변경 전 확인해주세요."
       classNames={{ ...commonModalStyles }}
     >
-      {requestedUnit !== null && (
-        <>
-          <span>{introduction[requestedUnit]}</span>
-          <CustomButton
-            size="sm"
-            styleType="primary"
-            title="그래도 변경하기"
-            onClick={handleChangeUnit}
-            style={{ marginTop: 16 }}
-          />
-        </>
-      )}
+      <span>{introduction[requestedUnit]}</span>
+      <CustomButton
+        size="sm"
+        styleType="primary"
+        title="그래도 변경하기"
+        onClick={handleChangeUnit}
+      />
     </Modal>
   );
 };

--- a/src/containers/photographer/mypage/schedule/time-block/confirm-modal.tsx
+++ b/src/containers/photographer/mypage/schedule/time-block/confirm-modal.tsx
@@ -8,9 +8,9 @@ import popToast from "@/components/common/toast";
 
 const introduction: { [keys in TimeUnitType]: string } = {
   THIRTY_MINUTES:
-    "오픈 시간을 30분으로 설정하시면, 이후에 다시 1시간으로 변경할 경우 기본 스케줄과 날짜별 스케줄이 모두 초기화됩니다.",
+    "예약 시간을 30분 단위로 설정하시면, 이후에 다시 1시간으로 변경할 경우 기본 스케줄과 날짜별 스케줄이 모두 초기화됩니다.",
   SIXTY_MINUTES:
-    "오픈 시간을 변경할 경우, 기본 스케줄과 날짜별 스케줄이 모두 초기화됩니다.",
+    "예약 시간을 1시간 단위로 변경할 경우, 기본 스케줄과 날짜별 스케줄이 모두 초기화됩니다.",
 };
 
 const ConfirmModal = ({

--- a/src/containers/photographer/mypage/schedule/time-block/confirm-modal.tsx
+++ b/src/containers/photographer/mypage/schedule/time-block/confirm-modal.tsx
@@ -1,0 +1,62 @@
+import { TimeUnitType } from "calender-types";
+import { Modal } from "@mantine/core";
+import { CustomButton } from "@/components/buttons/common-buttons";
+import { commonModalStyles } from "@/styles/mantine.css";
+import { responseHandler } from "@/services/common/error";
+import { putNewUnit } from "@/services/client/photographer/mypage/schedule";
+import popToast from "@/components/common/toast";
+
+const introduction: { [keys in TimeUnitType]: string } = {
+  THIRTY_MINUTES:
+    "오픈 시간을 30분으로 설정하시면, 이후에 다시 1시간으로 변경할 경우 기본 스케줄과 날짜별 스케줄이 모두 초기화됩니다.",
+  SIXTY_MINUTES:
+    "오픈 시간을 변경할 경우, 기본 스케줄과 날짜별 스케줄이 모두 초기화됩니다.",
+};
+
+const ConfirmModal = ({
+  onClose,
+  requestedUnit,
+}: {
+  onClose: () => void;
+  requestedUnit: null | TimeUnitType;
+}) => {
+  async function handleChangeUnit() {
+    if (requestedUnit) {
+      await responseHandler(
+        putNewUnit(requestedUnit),
+        () => {
+          onClose();
+          popToast("변경이 완료되었습니다.");
+        },
+        () => {
+          popToast("다시 시도해주세요.", "변경에 실패했습니다.", true);
+        },
+      );
+    }
+  }
+
+  return (
+    <Modal
+      onClose={onClose}
+      opened={requestedUnit !== null}
+      centered
+      title="변경 전 확인해주세요."
+      classNames={{ ...commonModalStyles }}
+    >
+      {requestedUnit !== null && (
+        <>
+          <span>{introduction[requestedUnit]}</span>
+          <CustomButton
+            size="sm"
+            styleType="primary"
+            title="그래도 변경하기"
+            onClick={handleChangeUnit}
+            style={{ marginTop: 16 }}
+          />
+        </>
+      )}
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/src/containers/photographer/mypage/schedule/time-block/index.tsx
+++ b/src/containers/photographer/mypage/schedule/time-block/index.tsx
@@ -1,22 +1,23 @@
 "use client";
 
-import { useState } from "react";
 import { TimeUnitType } from "calender-types";
 import Chip from "@/components/common/chip";
+import { useDisclosure } from "@mantine/hooks";
 import { scheduleStyles, timeblockStyles } from "../schedule.css";
 import ConfirmModal from "./confirm-modal";
 
+const UNIT_MAPPING: Record<TimeUnitType, TimeUnitType> = {
+  SIXTY_MINUTES: "THIRTY_MINUTES",
+  THIRTY_MINUTES: "SIXTY_MINUTES",
+};
+
 const TimeBlock = ({ currentUnit }: { currentUnit: TimeUnitType }) => {
-  const [requestedUnit, setRequestedUnit] = useState<TimeUnitType | null>(null);
+  const [opened, { open, close }] = useDisclosure(false);
 
-  function requestNewUnit(target: TimeUnitType) {
-    if (target !== currentUnit) {
-      setRequestedUnit(target);
+  function handleSelectUnit(selectedUnit: TimeUnitType) {
+    if (selectedUnit !== currentUnit) {
+      open();
     }
-  }
-
-  function cancelRequest() {
-    setRequestedUnit(null);
   }
 
   return (
@@ -25,17 +26,21 @@ const TimeBlock = ({ currentUnit }: { currentUnit: TimeUnitType }) => {
       <div className={timeblockStyles.wrapper}>
         <Chip
           name="30분마다"
-          onClick={() => requestNewUnit("THIRTY_MINUTES")}
+          onClick={() => handleSelectUnit("THIRTY_MINUTES")}
           selected={currentUnit === "THIRTY_MINUTES"}
         />
         <Chip
           name="1시간마다"
-          onClick={() => requestNewUnit("SIXTY_MINUTES")}
+          onClick={() => handleSelectUnit("SIXTY_MINUTES")}
           selected={currentUnit === "SIXTY_MINUTES"}
         />
         <span className={timeblockStyles.text}>오픈</span>
       </div>
-      <ConfirmModal onClose={cancelRequest} requestedUnit={requestedUnit} />
+      <ConfirmModal
+        opened={opened}
+        close={close}
+        requestedUnit={UNIT_MAPPING[currentUnit]}
+      />
     </div>
   );
 };

--- a/src/containers/photographer/mypage/schedule/time-block/index.tsx
+++ b/src/containers/photographer/mypage/schedule/time-block/index.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { TimeUnitType } from "calender-types";
+import Chip from "@/components/common/chip";
+import { scheduleStyles, timeblockStyles } from "../schedule.css";
+import ConfirmModal from "./confirm-modal";
+
+const TimeBlock = ({ currentUnit }: { currentUnit: TimeUnitType }) => {
+  const [requestedUnit, setRequestedUnit] = useState<TimeUnitType | null>(null);
+
+  function requestNewUnit(target: TimeUnitType) {
+    if (target !== currentUnit) {
+      setRequestedUnit(target);
+    }
+  }
+
+  function cancelRequest() {
+    setRequestedUnit(null);
+  }
+
+  return (
+    <div className={timeblockStyles.container}>
+      <span className={scheduleStyles.title}>예약 시간</span>
+      <div className={timeblockStyles.wrapper}>
+        <Chip
+          name="30분마다"
+          onClick={() => requestNewUnit("THIRTY_MINUTES")}
+          selected={currentUnit === "THIRTY_MINUTES"}
+        />
+        <Chip
+          name="1시간마다"
+          onClick={() => requestNewUnit("SIXTY_MINUTES")}
+          selected={currentUnit === "SIXTY_MINUTES"}
+        />
+        <span className={timeblockStyles.text}>오픈</span>
+      </div>
+      <ConfirmModal onClose={cancelRequest} requestedUnit={requestedUnit} />
+    </div>
+  );
+};
+
+export default TimeBlock;

--- a/src/services/client/photographer/mypage/schedule.ts
+++ b/src/services/client/photographer/mypage/schedule.ts
@@ -1,8 +1,30 @@
-import { TimeUnitType } from "calender-types";
+import {
+  BasicScheduleForm,
+  BasicScheduleResponse,
+  DaysType,
+  TimeUnitType,
+} from "calender-types";
 import apiClient from "../../core";
 
 export async function putNewUnit(data: TimeUnitType) {
   await apiClient.put("photographer/schedule/unit", {
     json: { scheduleUnit: data },
+  });
+}
+
+export async function putNewBaseSchedule(form: BasicScheduleForm) {
+  const data: BasicScheduleResponse = Object.entries(form).map(
+    ([title, value]) => {
+      const dayOfWeek = title as DaysType;
+      return {
+        dayOfWeek,
+        startTime: value.startTime,
+        endTime: value.endTime,
+        operationStatus: value.isOff ? "INACTIVE" : "ACTIVE",
+      };
+    },
+  );
+  await apiClient.put("photographer/schedule/base", {
+    json: { data },
   });
 }

--- a/src/services/client/photographer/mypage/schedule.ts
+++ b/src/services/client/photographer/mypage/schedule.ts
@@ -1,0 +1,8 @@
+import { TimeUnitType } from "calender-types";
+import apiClient from "../../core";
+
+export async function putNewUnit(data: TimeUnitType) {
+  await apiClient.put("photographer/schedule/unit", {
+    json: { scheduleUnit: data },
+  });
+}

--- a/src/services/client/photographer/mypage/schedule.ts
+++ b/src/services/client/photographer/mypage/schedule.ts
@@ -1,6 +1,6 @@
 import {
-  BasicScheduleForm,
-  BasicScheduleResponse,
+  BaseScheduleForm,
+  BaseScheduleResponse,
   DaysType,
   TimeUnitType,
 } from "calender-types";
@@ -12,8 +12,8 @@ export async function putNewUnit(data: TimeUnitType) {
   });
 }
 
-export async function putNewBaseSchedule(form: BasicScheduleForm) {
-  const data: BasicScheduleResponse = Object.entries(form).map(
+export async function putNewBaseSchedule(form: BaseScheduleForm) {
+  const data: BaseScheduleResponse = Object.entries(form).map(
     ([title, value]) => {
       const dayOfWeek = title as DaysType;
       return {

--- a/src/services/server/photographer/mypage/schedule.ts
+++ b/src/services/server/photographer/mypage/schedule.ts
@@ -1,21 +1,21 @@
 import {
-  BasicScheduleForm,
-  BasicScheduleResponse,
+  BaseScheduleForm,
+  BaseScheduleResponse,
   TimeUnitType,
 } from "calender-types";
 import { api } from "../../core";
 
-export async function getCurrentBaseSchedule(): Promise<BasicScheduleForm> {
+export async function getCurrentBaseSchedule(): Promise<BaseScheduleForm> {
   const { data } = await api
     .get("photographer/schedule/base")
-    .json<{ data: BasicScheduleResponse }>();
+    .json<{ data: BaseScheduleResponse }>();
   return data.reduce((acc, item) => {
     acc[item.dayOfWeek] = {
       ...item,
       isOff: item.operationStatus === "INACTIVE",
     };
     return acc;
-  }, {} as BasicScheduleForm);
+  }, {} as BaseScheduleForm);
 }
 
 export async function getCurrentUnit(): Promise<TimeUnitType> {

--- a/src/services/server/photographer/mypage/schedule.ts
+++ b/src/services/server/photographer/mypage/schedule.ts
@@ -1,0 +1,26 @@
+import {
+  BasicScheduleForm,
+  BasicScheduleResponse,
+  TimeUnitType,
+} from "calender-types";
+import { api } from "../../core";
+
+export async function getCurrentBaseSchedule(): Promise<BasicScheduleForm> {
+  const { data } = await api
+    .get("photographer/schedule/base")
+    .json<{ data: BasicScheduleResponse }>();
+  return data.reduce((acc, item) => {
+    acc[item.dayOfWeek] = {
+      ...item,
+      isOff: item.operationStatus === "INACTIVE",
+    };
+    return acc;
+  }, {} as BasicScheduleForm);
+}
+
+export async function getCurrentUnit(): Promise<TimeUnitType> {
+  const { data } = await api
+    .get("photographer/schedule/unit")
+    .json<{ data: { scheduleUnit: TimeUnitType } }>();
+  return data.scheduleUnit;
+}

--- a/src/styles/mantine.css.ts
+++ b/src/styles/mantine.css.ts
@@ -45,3 +45,39 @@ export const carouselStyles = styleVariants({
     },
   },
 });
+
+export const commonModalStyles = styleVariants({
+  content: {
+    borderRadius: 16,
+    padding: "0px 16px 16px 16px",
+  },
+  header: {
+    padding: 30,
+    justifyContent: "center",
+    alignItems: "flex-start",
+  },
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  title: [
+    texts["headline-02"],
+    sprinkles({
+      color: "text-point",
+    }),
+  ],
+  info: [
+    texts["body-02"],
+    sprinkles({
+      color: "text-02",
+    }),
+  ],
+  close: {
+    position: "absolute",
+    top: 25,
+    right: 10,
+  },
+});

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -9,12 +9,14 @@ declare module "calender-types" {
     | "SATURDAY"
     | "SUNDAY";
 
+  interface BasicScheduleType {
+    startTime: string;
+    endTime: string;
+    isOff: boolean;
+  }
+
   type BasicScheduleForm = {
-    [key in DaysType]: {
-      startTime: string;
-      endTime: string;
-      isOff: boolean;
-    };
+    [key in DaysType]: BasicScheduleType;
   };
 
   type BasicScheduleResponse = {

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -1,0 +1,24 @@
+declare module "calender-types" {
+  type TimeUnitType = "THIRTY_MINUTES" | "SIXTY_MINUTES";
+  type DaysType =
+    | "MONDAY"
+    | "TUESDAY"
+    | "WEDNESDAY"
+    | "THURSDAY"
+    | "FRIDAY"
+    | "SATURDAY"
+    | "SUNDAY";
+
+  interface BasicScheduleType {
+    id: number;
+    name: string;
+  }
+
+  type BasicScheduleForm = {
+    [key in DaysType]: {
+      startTime: string;
+      endTime: string;
+      isOff: boolean;
+    };
+  };
+}

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -9,11 +9,6 @@ declare module "calender-types" {
     | "SATURDAY"
     | "SUNDAY";
 
-  interface BasicScheduleType {
-    id: number;
-    name: string;
-  }
-
   type BasicScheduleForm = {
     [key in DaysType]: {
       startTime: string;
@@ -21,4 +16,11 @@ declare module "calender-types" {
       isOff: boolean;
     };
   };
+
+  type BasicScheduleResponse = {
+    dayOfWeek: DaysType;
+    startTime: string;
+    endTime: string;
+    operationStatus: "ACTIVE" | "INACTIVE";
+  }[];
 }

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -9,17 +9,17 @@ declare module "calender-types" {
     | "SATURDAY"
     | "SUNDAY";
 
-  interface BasicScheduleType {
+  interface BaseScheduleType {
     startTime: string;
     endTime: string;
     isOff: boolean;
   }
 
-  type BasicScheduleForm = {
-    [key in DaysType]: BasicScheduleType;
+  type BaseScheduleForm = {
+    [key in DaysType]: BaseScheduleType;
   };
 
-  type BasicScheduleResponse = {
+  type BaseScheduleResponse = {
     dayOfWeek: DaysType;
     startTime: string;
     endTime: string;


### PR DESCRIPTION
## 체크리스트
- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- 기본 스케줄 및 예약 오픈 시간 단위 설정
예약 오픈 시간 단위 변경, 요일별 운영 시간표 확인 및 수정, 휴무일로 변경

## 고민한 사항
- 시간값 관리

TypeScript에서 제공하는 Date 객체의 경우 날짜에 대한 정보 없이 시간을 정의하는 게 불가능해서, 특정 날짜에 종속적이지 않은 운영 스케줄을 어떻게 관리할지 고민이 있었습니다. 직접 타입을 정의하는 것도 고려해 봤으나, 운영 시간의 유효성 검증 / 날짜별 스케줄 및 예약 시간 설정시 비교 필요 등 시간에 관한 연산 혹은 비교 기능이 다수 필요해질 것으로 예상되었습니다. 관련 라이브러리 중 시간만 독립적으로 관리할 수 있는 [luxon](https://moment.github.io/luxon/#/?id=luxon)을 추가해 사용하게 되었습니다.

추가로, luxon을 통해 정의한 DateTime을 어느 범위까지 사용하고, 어느 범위에서 해당 값을 포맷팅한 string을 들고 있을지 고민이 있었습니다. 현재는 시간 값을 직접 수정하는 컴포넌트에서만 DateTime 객체를 변환해서 사용하고 있는데, 이후에 의존성과 복잡성을 좀 더 고려해 보고 네이티브 Date + 직접 정의한 유틸 함수를 이용하던 부분까지 일관적으로 DateTime을 사용하게 리팩토링해 보는 것도 괜찮을 것 같다는 생각이 들었습니다 ㅎ.ㅎ…

- 컴포넌트 설계 관련

개발을 잠깐 쉬었더니 컴포넌트를 적당히 쪼개고 책임을 분리하는 데도 고민이 좀 있었습니다. 예약 시간 단위를 선택하는 경우, 변경 전 보여 주는 모달에서 변경할 시간 단위 값을 가지고 있어야 했는데, 처음에는 다음과 같이 구현했습니다.
> 상위 컴포넌트에서 "사용자가 변경하려고 하는 시간 단위"를 상태로 관리하며 하위 컴포넌트(모달)에 전달 
> 사용자가 시간 단위 클릭시 해당 단위로 상태를 변경하고, 변경을 취소했을 때는 (모달을 닫는 등) null 값을 갖고 있음 

단 이 경우 모달에서 null 값에 대한 예외 처리가 필요하고, 시간 단위는 추후에 여러 개의 옵션으로 늘어날 가능성이 낮을 것으로 예상되어 불필요한 리렌더링을 감수하며 상태로 관리할 필요가 없다는 생각이 들었습니다. 결과적으로 현재의 시간 단위를 기준으로 변경 가능한 시간 단위를 판단해 하위 컴포넌트에 내려 주는 방식으로 리팩토링했습니다 😌

## 리뷰 요청사항
- api 호출

`src/services/client/photographer/mypage/schedule.ts`: 기본 스케줄 & 시간 단위 수정
`src/services/server/photographer/mypage/schedule.ts`: 기본 스케줄 & 시간 단위 조회 

(+ 둘 다 페이지에서 페칭한 뒤 하위로 내려 주고 있습니다. 날짜별 스케줄의 경우 (지난 예약 건 조회처럼!) Suspense를 포함한 클라이언트 사이드 데이터 페칭으로 생각 중입니다.)

- UI/UX 관련
기존 디자인과 차이가 커서 UI가 어색하거나 직관적이지 않은 부분 있다면 피드백 부탁드려요! 😓 아래는 개인적으로 고민됐던 부분들입니다

> - 각 요일을 클릭해서 휴무일 / 영업일 변경하는 것 직관적인지
> - 예약 시간 변경 요청시 안내하는 내용에 더 추가할 부분 없는지
> - 시간 선택창의 경우 따로 `닫기` 버튼을 넣기에는 버튼이 너무 많아지는 것 같아 제외했는데 (열린 상태에서 바깥 아무데나 누르면 닫힘) 괜찮은지
> - `시작 시간`은 현재 설정한 `종료 시간` 이전으로만, `종료 시간`은 현재 설정한 `시작 시간` 이후로만 선택할 수 있게 제한하고 있는데 이런 방식이 오히려 더 불편하게 느껴지지는 않을지

- 시급도: `높음`
스케줄 관련 기본 세팅을 해서 이후 티켓 작업에 전부 엮이는 부분이 있을 것 같습니다!

## 스크린샷
![FU-345](https://github.com/user-attachments/assets/a44d0e9c-2ab6-4170-a267-e7ed5f722e31)
![스크린샷 2024-12-17 오후 3 38 07](https://github.com/user-attachments/assets/7452206b-42cc-4073-93ba-93d77fbf7a61)
(* 30분 / 1시간 변경시 모달 화면, 30분 옵션 사용할 경우 시간 선택창)

[FU-345]: https://for-u.atlassian.net/browse/FU-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ