### PR TITLE
[FU-347] daily schedule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,6 +40,8 @@
     "react/function-component-definition": [
       2,
       { "namedComponents": ["arrow-function", "function-declaration"] }
-    ]
+    ],
+    "no-nested-ternary": "off",
+    "react/destructuring-assignment": "off"
   }
 }

--- a/src/components/inputs/input.css.ts
+++ b/src/components/inputs/input.css.ts
@@ -2,21 +2,37 @@ import sprinkles from "@/styles/sprinkles.css";
 import { texts } from "@/styles/text.css";
 import { style, styleVariants } from "@vanilla-extract/css";
 
+const baseTimeSelectorContainer = style([
+  sprinkles({
+    borderColor: "stroke-grey",
+    color: "text-01",
+  }),
+  texts["body-01"],
+  {
+    width: 90,
+    position: "relative",
+    borderRadius: 8,
+    borderWidth: 1,
+    borderStyle: "solid",
+    padding: "8px 18px",
+  },
+]);
+
 export const timeSelectorStyles = styleVariants({
   container: [
     sprinkles({
       backgroundColor: "white",
-      borderColor: "stroke-grey",
-      color: "text-01",
     }),
-    texts["body-01"],
+    baseTimeSelectorContainer,
+  ],
+  disabledContainer: [
+    sprinkles({ backgroundColor: "bg-lightgrey" }),
+    baseTimeSelectorContainer,
     {
-      width: 90,
-      position: "relative",
-      borderRadius: 8,
-      borderWidth: 1,
-      borderStyle: "solid",
-      padding: "8px 18px",
+      cursor: "default",
+      ":hover": {
+        filter: "none",
+      },
     },
   ],
   dropdown: [

--- a/src/components/inputs/time-selector.tsx
+++ b/src/components/inputs/time-selector.tsx
@@ -9,12 +9,14 @@ const TimeSelector = ({
   minTime,
   maxTime,
   unit,
+  disabled,
 }: {
   time: string;
   setTime: (newTime: string) => void;
   minTime?: string;
   maxTime?: string;
   unit: TimeUnitType;
+  disabled?: boolean;
 }) => {
   const hours = [
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
@@ -52,9 +54,21 @@ const TimeSelector = ({
   }
 
   return (
-    <Menu closeOnItemClick={false} withArrow position="bottom">
+    <Menu
+      disabled={disabled}
+      closeOnItemClick={false}
+      withArrow
+      position="bottom"
+    >
       <Menu.Target>
-        <button className={timeSelectorStyles.container} type="button">
+        <button
+          className={
+            disabled
+              ? timeSelectorStyles.disabledContainer
+              : timeSelectorStyles.container
+          }
+          type="button"
+        >
           {timeValue.toFormat("HH:mm")}
         </button>
       </Menu.Target>

--- a/src/constants/schedule.ts
+++ b/src/constants/schedule.ts
@@ -1,4 +1,4 @@
-import { DaysType } from "calender-types";
+import { DaysType, ScheduleStatusType } from "calender-types";
 
 export const daysArray: DaysType[] = [
   "MONDAY",
@@ -18,4 +18,10 @@ export const dayNames: { [key in DaysType]: string } = {
   FRIDAY: "금",
   SATURDAY: "토",
   SUNDAY: "일",
+};
+
+export const statusNames: { [key in ScheduleStatusType]: string } = {
+  CLOSED: "예약 중지",
+  OPEN: "추가 오픈",
+  CONFIRMED: "촬영 확정",
 };

--- a/src/containers/photographer/mypage/schedule/base/index.tsx
+++ b/src/containers/photographer/mypage/schedule/base/index.tsx
@@ -67,8 +67,11 @@ const BaseSchedule = ({
             </button>
           </div>
           <Collapse in={opened}>
+            <InfoCaption
+              information="각 요일을 클릭해 휴무일로 변경할 수 있습니다."
+              container={{ marginTop: 12 }}
+            />
             <div className={scheduleStyles.body}>
-              <InfoCaption information="각 요일을 클릭해 휴무일로 변경할 수 있습니다." />
               {daysArray.map((day) => (
                 <DaySchedule day={day} unit={unit} key={day} />
               ))}

--- a/src/containers/photographer/mypage/schedule/daily/daily.css.ts
+++ b/src/containers/photographer/mypage/schedule/daily/daily.css.ts
@@ -4,6 +4,51 @@ import { texts } from "@/styles/text.css";
 import { CalendarStylesNames } from "@mantine/dates";
 import { ComplexStyleRule, styleVariants } from "@vanilla-extract/css";
 
+export const listStyles = styleVariants({
+  status: [texts["headline-03"], sprinkles({ color: "text-point" })],
+  info: [texts["body-02"], sprinkles({ color: "text-03" })],
+  wrapper: {
+    marginTop: 8,
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+});
+
+export const viewStyles = styleVariants({
+  container: [
+    sprinkles({ borderColor: "stroke-grey" }),
+    {
+      flex: 1,
+      minWidth: 420,
+      width: "100%",
+      padding: 20,
+      marginTop: 10,
+      borderRadius: 16,
+      borderWidth: 1,
+      borderStyle: "solid",
+    },
+  ],
+  dateInfo: {
+    marginBottom: 16,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  date: [
+    texts["headline-02"],
+    sprinkles({ color: "text-02" }),
+    { marginBottom: 8, display: "block" },
+  ],
+  baseSchedule: [texts["body-02"], sprinkles({ color: "text-03" })],
+  scheduleWrapper: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 16,
+    padding: "16px 0px",
+  },
+});
+
 export const dailyStyles = styleVariants({
   body: {
     display: "flex",

--- a/src/containers/photographer/mypage/schedule/daily/daily.css.ts
+++ b/src/containers/photographer/mypage/schedule/daily/daily.css.ts
@@ -4,6 +4,44 @@ import { texts } from "@/styles/text.css";
 import { CalendarStylesNames } from "@mantine/dates";
 import { ComplexStyleRule, styleVariants } from "@vanilla-extract/css";
 
+export const modalStyles = styleVariants({
+  timeWrapper: [
+    sprinkles({ color: "text-02" }),
+    texts["headline-03"],
+    {
+      display: "flex",
+      flexWrap: "wrap",
+      alignItems: "center",
+      gap: 8,
+    },
+  ],
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: 20,
+    width: "100%",
+  },
+  dateInfo: {
+    marginBottom: 16,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  date: [
+    texts["headline-02"],
+    sprinkles({ color: "text-02" }),
+    { marginBottom: 8, display: "block" },
+  ],
+  baseSchedule: [texts["body-02"], sprinkles({ color: "text-03" })],
+  buttonWrapper: {
+    display: "flex",
+    gap: 8,
+    marginTop: 20,
+    width: "100%",
+  },
+});
+
 export const listStyles = styleVariants({
   status: [texts["headline-03"], sprinkles({ color: "text-point" })],
   info: [texts["body-02"], sprinkles({ color: "text-03" })],

--- a/src/containers/photographer/mypage/schedule/daily/daily.css.ts
+++ b/src/containers/photographer/mypage/schedule/daily/daily.css.ts
@@ -1,0 +1,84 @@
+import { breakpoints } from "@/styles/breakpoints.css";
+import sprinkles from "@/styles/sprinkles.css";
+import { texts } from "@/styles/text.css";
+import { CalendarStylesNames } from "@mantine/dates";
+import { ComplexStyleRule, styleVariants } from "@vanilla-extract/css";
+
+export const dailyStyles = styleVariants({
+  body: {
+    display: "flex",
+    padding: "16px 0px 24px 0px",
+    gap: 20,
+
+    "@media": {
+      [breakpoints.mobile]: {
+        flexDirection: "column",
+        alignItems: "center",
+      },
+    },
+  },
+  calenderTitle: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
+  month: [texts["headline-02"], sprinkles({ color: "text-point" })],
+  year: [texts["headline-03"], sprinkles({ color: "text-03" })],
+  indicatorWrapper: {
+    position: "absolute",
+    bottom: -15,
+    height: 10,
+    width: "100%",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 2,
+  },
+  indicator: { width: 10, height: 10, borderRadius: 10 },
+  CLOSED: [sprinkles({ backgroundColor: "pink" })],
+  CONFIRMED: [sprinkles({ backgroundColor: "blue" })],
+  OPEN: [sprinkles({ backgroundColor: "green" })],
+  selected: [sprinkles({ color: "white" })],
+  weekend: [sprinkles({ color: "pink" })],
+  weekday: [sprinkles({ color: "text-02" })],
+});
+
+export const customedCalendarStyles = styleVariants<
+  Partial<Record<CalendarStylesNames, ComplexStyleRule>>
+>({
+  calendarHeaderLevel: {
+    flex: 0,
+    padding: "6px 24px",
+    minHeight: "fit-content",
+    minWidth: "fit-content",
+  },
+  calendarHeader: {
+    gap: 20,
+    margin: "auto",
+    marginBottom: 10,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  calendarHeaderControl: [
+    sprinkles({ backgroundColor: "bg-lightgrey", color: "blue" }),
+    { borderRadius: 100, width: 24, height: 24 },
+  ],
+  calendarHeaderControlIcon: { width: "60%", height: "60%" },
+  monthsListControl: [
+    texts["headline-03"],
+    sprinkles({ color: "text-02" }),
+    { margin: 15 },
+  ],
+  monthCell: [texts["headline-03"], sprinkles({ color: "text-02" })],
+  weekdaysRow: [
+    sprinkles({ backgroundColor: "bg-lightgrey", color: "text-02" }),
+    { verticalAlign: "middle", height: 36 },
+  ],
+  weekday: { padding: 0 },
+  day: {
+    position: "relative",
+    borderRadius: 100,
+    padding: 10,
+    margin: 15,
+  },
+});

--- a/src/containers/photographer/mypage/schedule/daily/edit-modal.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/edit-modal.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from "react";
+import {
+  BaseScheduleType,
+  DailyScheduleValue,
+  ScheduleStatusType,
+  TimeUnitType,
+} from "calender-types";
+import { DateTime } from "luxon";
+import { Divider, Modal, SegmentedControl } from "@mantine/core";
+import TimeSelector from "@/components/inputs/time-selector";
+import popToast from "@/components/common/toast";
+import InfoCaption from "@/components/common/info-caption";
+import { CustomButton } from "@/components/buttons/common-buttons";
+import { statusNames } from "@/constants/schedule";
+import { commonModalStyles } from "@/styles/mantine.css";
+import { formatTimeString } from "@/utils/date";
+import { responseHandler } from "@/services/common/error";
+import {
+  deleteDailySchedule,
+  postDailySchedule,
+  putDailySchedule,
+} from "@/services/client/photographer/mypage/schedule";
+import { modalStyles } from "./daily.css";
+
+const EditModal = ({
+  opened,
+  close,
+  initValue,
+  unit,
+  baseSchedule,
+  date,
+}: {
+  opened: boolean;
+  close: () => void;
+  date: Date;
+  initValue?: DailyScheduleValue;
+  unit: TimeUnitType;
+  baseSchedule: BaseScheduleType;
+}) => {
+  const defaultSchedule: DailyScheduleValue = {
+    date: DateTime.fromJSDate(date),
+    scheduleId: 0,
+    startTime: DateTime.fromObject({ hour: 12 }),
+    endTime: DateTime.fromObject({ hour: 13 }),
+    scheduleStatus: "OPEN",
+  };
+  const STATUS_LIST: ScheduleStatusType[] = ["OPEN", "CLOSED", "CONFIRMED"];
+
+  const [scheduleValue, setScheduleValue] = useState<DailyScheduleValue>(
+    initValue || defaultSchedule,
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    setScheduleValue(initValue || defaultSchedule);
+  }, [date, initValue]);
+
+  async function handleSubmit() {
+    setIsSubmitting(true);
+    await responseHandler(
+      initValue
+        ? putDailySchedule(scheduleValue)
+        : postDailySchedule(scheduleValue),
+      () => {
+        popToast("저장이 완료되었습니다.");
+        close();
+      },
+      (message) =>
+        popToast("다시 시도해주세요.", message || "저장에 실패했습니다.", true),
+    );
+    setIsSubmitting(false);
+  }
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    await responseHandler(
+      deleteDailySchedule(scheduleValue.scheduleId),
+      () => {
+        popToast("삭제가 완료되었습니다.");
+        close();
+      },
+      (message) =>
+        popToast("다시 시도해주세요.", message || "삭제에 실패했습니다.", true),
+    );
+    setIsDeleting(false);
+  }
+
+  function updateStatus(selectedStatus: string) {
+    setScheduleValue((prev) => {
+      return { ...prev, scheduleStatus: selectedStatus as ScheduleStatusType };
+    });
+  }
+
+  function updateTime(newTime: string, value: "startTime" | "endTime") {
+    setScheduleValue((prev) => {
+      const newValue =
+        value === "startTime"
+          ? { ...prev, startTime: DateTime.fromFormat(newTime, "HH:mm:ss") }
+          : { ...prev, endTime: DateTime.fromFormat(newTime, "HH:mm:ss") };
+      return newValue;
+    });
+  }
+
+  return (
+    <Modal
+      centered
+      opened={opened}
+      onClose={close}
+      title={initValue ? "날짜별 스케줄 수정" : "날짜별 스케줄 추가"}
+      classNames={{ ...commonModalStyles, ...modalStyles }}
+    >
+      <div>
+        <span className={modalStyles.date}>
+          {`${scheduleValue.date.year}.${scheduleValue.date.month}.${scheduleValue.date.day} (${scheduleValue.date.weekdayShort})`}
+        </span>
+        <span className={modalStyles.baseSchedule}>
+          {baseSchedule.isOff
+            ? "휴무일입니다."
+            : `시작 시간 ${formatTimeString(baseSchedule.startTime)} ~ 종료 시간 ${formatTimeString(baseSchedule.endTime)}`}
+        </span>
+      </div>
+      <Divider style={{ width: "100%" }} />
+      <div>
+        <SegmentedControl
+          data={STATUS_LIST.map((status) => {
+            return { value: status, label: statusNames[status] };
+          })}
+          value={scheduleValue.scheduleStatus}
+          onChange={updateStatus}
+          color="var(--mantine-primary-color-filled)"
+        />
+        <InfoCaption
+          information={
+            scheduleValue.scheduleStatus === "OPEN"
+              ? "스케줄을 저장하면 해당 시간대에 고객이 예약을 신청할 수 있습니다."
+              : "스케줄을 저장하면 해당 시간대에 고객이 예약을 신청할 수 없습니다."
+          }
+          container={{ marginTop: 8 }}
+        />
+      </div>
+      <div className={modalStyles.timeWrapper}>
+        <span>시작 시간</span>
+        <TimeSelector
+          time={scheduleValue.startTime.toFormat("HH:mm:ss")}
+          setTime={(newTime) => updateTime(newTime, "startTime")}
+          maxTime={scheduleValue.endTime.toFormat("HH:mm:ss")}
+          unit={unit}
+        />
+        <span>~</span>
+        <span>종료 시간</span>
+        <TimeSelector
+          time={scheduleValue.endTime.toFormat("HH:mm:ss")}
+          setTime={(newTime) => updateTime(newTime, "endTime")}
+          minTime={scheduleValue.startTime.toFormat("HH:mm:ss")}
+          unit={unit}
+        />
+      </div>
+      <div className={modalStyles.buttonWrapper}>
+        {initValue && (
+          <CustomButton
+            size="md"
+            styleType="secondary"
+            title="삭제하기"
+            onClick={handleDelete}
+            loading={isDeleting}
+            style={{ flex: 1 }}
+          />
+        )}
+        <CustomButton
+          size="md"
+          styleType="primary"
+          title="저장하기"
+          onClick={handleSubmit}
+          loading={isSubmitting}
+          style={{ flex: 1 }}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default EditModal;

--- a/src/containers/photographer/mypage/schedule/daily/edit-modal.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/edit-modal.tsx
@@ -156,7 +156,7 @@ const EditModal = ({
       </div>
       <Divider style={{ width: "100%" }} />
       <div>
-        {isDone && (
+        {isDone && initValue && (
           <InfoCaption
             information="이미 완료된 스케줄이므로 수정이 불가능합니다."
             container={{ marginBottom: 8 }}
@@ -171,7 +171,7 @@ const EditModal = ({
           disabled={isStarted}
           color="var(--mantine-primary-color-filled)"
         />
-        {!isDone && (
+        {(!isDone || !initValue) && (
           <InfoCaption
             information={
               scheduleValue.scheduleStatus === "OPEN"

--- a/src/containers/photographer/mypage/schedule/daily/edit-modal.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/edit-modal.tsx
@@ -62,8 +62,8 @@ const EditModal = ({
     scheduleId: 0,
     startTime: defaultStartTime,
     endTime: DateTime.fromObject({
-      hour: unit === "SIXTY_MINUTES" ? 22 : 23,
-      minute: 0,
+      hour: 23,
+      minute: unit === "SIXTY_MINUTES" ? 0 : 30,
     }),
     scheduleStatus: "OPEN",
   };

--- a/src/containers/photographer/mypage/schedule/daily/index.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/index.tsx
@@ -69,12 +69,15 @@ const DailySchedule = ({
   unit: TimeUnitType;
 }) => {
   const [selectedDate, setSelectedDate] = useState(new Date());
-  const [viewDate, setViewDate] = useState(new Date());
   const { data: dailySchedules, error } = useSuspenseQuery({
-    queryKey: ["dailySchedule", { viewDate }],
+    queryKey: [
+      "dailySchedule",
+      selectedDate.getFullYear(),
+      selectedDate.getMonth(),
+    ],
     initialData: new Map<number, DailyScheduleList>(),
     staleTime: 0,
-    queryFn: () => getDailySchedules(viewDate),
+    queryFn: () => getDailySchedules(selectedDate),
     retry: false,
   });
 
@@ -90,7 +93,6 @@ const DailySchedule = ({
 
   function changeMonth(date: DateValue) {
     if (date) {
-      setViewDate(date);
       date.setDate(1);
       setSelectedDate(date);
     }

--- a/src/containers/photographer/mypage/schedule/daily/index.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/index.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import "dayjs/locale/ko";
+import { useState } from "react";
+import { DateTime } from "luxon";
+import { DailyScheduleValue } from "calender-types";
+import { DatePicker, DateValue } from "@mantine/dates";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getDailySchedules } from "@/services/client/photographer/mypage/schedule";
+import { scheduleStyles } from "../schedule.css";
+import { customedCalendarStyles, dailyStyles } from "./daily.css";
+
+const CalendarLabel = (current: Date, level: "year" | "month") => {
+  return (
+    <div className={dailyStyles.calenderTitle}>
+      {level === "month" && (
+        <span className={dailyStyles.year}>{current.getFullYear()}</span>
+      )}
+      <span className={dailyStyles.month}>
+        {level === "month"
+          ? `${current.getMonth() + 1}월`
+          : current.getFullYear()}
+      </span>
+    </div>
+  );
+};
+
+const CalendarDay = (
+  date: Date,
+  schedules: ("OPEN" | "CLOSED" | "CONFIRMED")[],
+  selected: boolean,
+) => {
+  return (
+    <>
+      <span
+        className={
+          selected
+            ? dailyStyles.selected
+            : date.getDay() === 0
+              ? dailyStyles.weekend
+              : dailyStyles.weekday
+        }
+      >
+        {date.getDate()}
+      </span>
+      <div className={dailyStyles.indicatorWrapper}>
+        {schedules.slice(0, 3).map((status) => (
+          <div
+            key={status}
+            className={`${dailyStyles.indicator} ${dailyStyles[status]}`}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+const DailySchedule = () => {
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [viewDate, setViewDate] = useState(new Date());
+  const { data: dailySchedules, error } = useSuspenseQuery({
+    queryKey: ["dailySchedule", { viewDate }],
+    initialData: new Map<number, DailyScheduleValue>(),
+    staleTime: 0,
+    queryFn: () => getDailySchedules(viewDate),
+    retry: false,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  function changeDate(date: DateValue) {
+    if (date) {
+      setSelectedDate(date);
+    }
+  }
+
+  function changeMonth(date: DateValue) {
+    if (date) {
+      setViewDate(date);
+    }
+  }
+
+  return (
+    <div>
+      <span className={scheduleStyles.title}>날짜별 스케줄</span>
+      <div className={dailyStyles.body}>
+        <DatePicker
+          onNextMonth={changeMonth}
+          onMonthSelect={changeMonth}
+          maxLevel="year"
+          locale="ko"
+          size="md"
+          value={selectedDate}
+          onChange={changeDate}
+          classNames={{ ...customedCalendarStyles }}
+          monthLabelFormat={(month) => CalendarLabel(month, "month")}
+          yearLabelFormat={(year) => CalendarLabel(year, "year")}
+          renderDay={(date) =>
+            CalendarDay(
+              date,
+              dailySchedules
+                .get(date.getDate())
+                ?.map(({ scheduleStatus }) => scheduleStatus) || [],
+              DateTime.fromJSDate(date).hasSame(
+                DateTime.fromJSDate(selectedDate),
+                "day",
+              ),
+            )
+          }
+          firstDayOfWeek={0}
+          weekendDays={[0]}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DailySchedule;

--- a/src/containers/photographer/mypage/schedule/daily/index.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/index.tsx
@@ -3,11 +3,13 @@
 import "dayjs/locale/ko";
 import { useState } from "react";
 import { DateTime } from "luxon";
-import { DailyScheduleValue } from "calender-types";
+import { BaseScheduleForm, DailyScheduleValue } from "calender-types";
 import { DatePicker, DateValue } from "@mantine/dates";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { daysArray } from "@/constants/schedule";
 import { getDailySchedules } from "@/services/client/photographer/mypage/schedule";
 import { scheduleStyles } from "../schedule.css";
+import ScheduleView from "./schedule-view";
 import { customedCalendarStyles, dailyStyles } from "./daily.css";
 
 const CalendarLabel = (current: Date, level: "year" | "month") => {
@@ -44,9 +46,9 @@ const CalendarDay = (
         {date.getDate()}
       </span>
       <div className={dailyStyles.indicatorWrapper}>
-        {schedules.slice(0, 3).map((status) => (
+        {schedules.slice(0, 3).map((status, index) => (
           <div
-            key={status}
+            key={index + status}
             className={`${dailyStyles.indicator} ${dailyStyles[status]}`}
           />
         ))}
@@ -55,7 +57,11 @@ const CalendarDay = (
   );
 };
 
-const DailySchedule = () => {
+const DailySchedule = ({
+  baseSchedule,
+}: {
+  baseSchedule: BaseScheduleForm;
+}) => {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [viewDate, setViewDate] = useState(new Date());
   const { data: dailySchedules, error } = useSuspenseQuery({
@@ -79,6 +85,8 @@ const DailySchedule = () => {
   function changeMonth(date: DateValue) {
     if (date) {
       setViewDate(date);
+      date.setDate(1);
+      setSelectedDate(date);
     }
   }
 
@@ -87,13 +95,15 @@ const DailySchedule = () => {
       <span className={scheduleStyles.title}>날짜별 스케줄</span>
       <div className={dailyStyles.body}>
         <DatePicker
-          onNextMonth={changeMonth}
-          onMonthSelect={changeMonth}
           maxLevel="year"
           locale="ko"
           size="md"
           value={selectedDate}
           onChange={changeDate}
+          onPreviousMonth={changeMonth}
+          onNextMonth={changeMonth}
+          onMonthSelect={changeMonth}
+          hideOutsideDates
           classNames={{ ...customedCalendarStyles }}
           monthLabelFormat={(month) => CalendarLabel(month, "month")}
           yearLabelFormat={(year) => CalendarLabel(year, "year")}
@@ -111,6 +121,13 @@ const DailySchedule = () => {
           }
           firstDayOfWeek={0}
           weekendDays={[0]}
+        />
+        <ScheduleView
+          baseSchedule={
+            baseSchedule[daysArray[(selectedDate.getDay() + 6) % 7]]
+          }
+          dailySchedules={dailySchedules.get(selectedDate.getDate()) || []}
+          date={selectedDate}
         />
       </div>
     </div>

--- a/src/containers/photographer/mypage/schedule/daily/index.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/index.tsx
@@ -3,7 +3,11 @@
 import "dayjs/locale/ko";
 import { useState } from "react";
 import { DateTime } from "luxon";
-import { BaseScheduleForm, DailyScheduleList } from "calender-types";
+import {
+  BaseScheduleForm,
+  DailyScheduleList,
+  TimeUnitType,
+} from "calender-types";
 import { DatePicker, DateValue } from "@mantine/dates";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { daysArray } from "@/constants/schedule";
@@ -59,8 +63,10 @@ const CalendarDay = (
 
 const DailySchedule = ({
   baseSchedule,
+  unit,
 }: {
   baseSchedule: BaseScheduleForm;
+  unit: TimeUnitType;
 }) => {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [viewDate, setViewDate] = useState(new Date());
@@ -128,6 +134,7 @@ const DailySchedule = ({
           }
           dailySchedules={dailySchedules.get(selectedDate.getDate()) || []}
           date={selectedDate}
+          unit={unit}
         />
       </div>
     </div>

--- a/src/containers/photographer/mypage/schedule/daily/index.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/index.tsx
@@ -3,7 +3,7 @@
 import "dayjs/locale/ko";
 import { useState } from "react";
 import { DateTime } from "luxon";
-import { BaseScheduleForm, DailyScheduleValue } from "calender-types";
+import { BaseScheduleForm, DailyScheduleList } from "calender-types";
 import { DatePicker, DateValue } from "@mantine/dates";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { daysArray } from "@/constants/schedule";
@@ -66,7 +66,7 @@ const DailySchedule = ({
   const [viewDate, setViewDate] = useState(new Date());
   const { data: dailySchedules, error } = useSuspenseQuery({
     queryKey: ["dailySchedule", { viewDate }],
-    initialData: new Map<number, DailyScheduleValue>(),
+    initialData: new Map<number, DailyScheduleList>(),
     staleTime: 0,
     queryFn: () => getDailySchedules(viewDate),
     retry: false,

--- a/src/containers/photographer/mypage/schedule/daily/schedule-list.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/schedule-list.tsx
@@ -1,4 +1,8 @@
-import { DailyScheduleList, ScheduleStatusType } from "calender-types";
+import {
+  DailyScheduleList,
+  DailyScheduleValue,
+  ScheduleStatusType,
+} from "calender-types";
 import { statusNames } from "@/constants/schedule";
 import Chip from "@/components/common/chip";
 import { listStyles } from "./daily.css";
@@ -6,9 +10,11 @@ import { listStyles } from "./daily.css";
 const ScheduleList = ({
   status,
   scheduleData,
+  onSelectSchedule,
 }: {
   status: ScheduleStatusType;
   scheduleData: DailyScheduleList;
+  onSelectSchedule: (scheduleValue: DailyScheduleValue) => void;
 }) => {
   return (
     <div>
@@ -18,7 +24,8 @@ const ScheduleList = ({
           scheduleData.map((schedule) => (
             <Chip
               key={schedule.scheduleId}
-              name={`${schedule.startTime.toFormat("HH:MM")} ~ ${schedule.endTime.toFormat("HH:MM")}`}
+              name={`${schedule.startTime.toFormat("HH:mm")} ~ ${schedule.endTime.toFormat("HH:mm")}`}
+              onClick={() => onSelectSchedule(schedule)}
             />
           ))
         ) : (

--- a/src/containers/photographer/mypage/schedule/daily/schedule-list.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/schedule-list.tsx
@@ -1,4 +1,4 @@
-import { DailyScheduleValue, ScheduleStatusType } from "calender-types";
+import { DailyScheduleList, ScheduleStatusType } from "calender-types";
 import { statusNames } from "@/constants/schedule";
 import Chip from "@/components/common/chip";
 import { listStyles } from "./daily.css";
@@ -8,7 +8,7 @@ const ScheduleList = ({
   scheduleData,
 }: {
   status: ScheduleStatusType;
-  scheduleData: DailyScheduleValue;
+  scheduleData: DailyScheduleList;
 }) => {
   return (
     <div>

--- a/src/containers/photographer/mypage/schedule/daily/schedule-list.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/schedule-list.tsx
@@ -1,0 +1,34 @@
+import { DailyScheduleValue, ScheduleStatusType } from "calender-types";
+import { statusNames } from "@/constants/schedule";
+import Chip from "@/components/common/chip";
+import { listStyles } from "./daily.css";
+
+const ScheduleList = ({
+  status,
+  scheduleData,
+}: {
+  status: ScheduleStatusType;
+  scheduleData: DailyScheduleValue;
+}) => {
+  return (
+    <div>
+      <span className={listStyles.status}>{statusNames[status]}</span>
+      <div className={listStyles.wrapper}>
+        {scheduleData.length > 0 ? (
+          scheduleData.map((schedule) => (
+            <Chip
+              key={schedule.scheduleId}
+              name={`${schedule.startTime.toFormat("HH:MM")} ~ ${schedule.endTime.toFormat("HH:MM")}`}
+            />
+          ))
+        ) : (
+          <span className={listStyles.info}>
+            아직 등록된 스케줄이 없습니다.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleList;

--- a/src/containers/photographer/mypage/schedule/daily/schedule-view.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/schedule-view.tsx
@@ -1,4 +1,4 @@
-import { BaseScheduleType, DailyScheduleValue } from "calender-types";
+import { BaseScheduleType, DailyScheduleList } from "calender-types";
 import { formatTimeString } from "@/utils/date";
 import { Divider } from "@mantine/core";
 import { CustomButton } from "@/components/buttons/common-buttons";
@@ -10,7 +10,7 @@ const ScheduleView = ({
   dailySchedules,
   date,
 }: {
-  dailySchedules: DailyScheduleValue;
+  dailySchedules: DailyScheduleList;
   baseSchedule: BaseScheduleType;
   date: Date;
 }) => {

--- a/src/containers/photographer/mypage/schedule/daily/schedule-view.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/schedule-view.tsx
@@ -8,7 +8,7 @@ import {
 } from "calender-types";
 import { useDisclosure } from "@mantine/hooks";
 import { formatTimeString } from "@/utils/date";
-import { Divider } from "@mantine/core";
+import { Divider, Tooltip } from "@mantine/core";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import { viewStyles } from "./daily.css";
 import ScheduleList from "./schedule-list";
@@ -36,6 +36,10 @@ const ScheduleView = ({
     setSelectedSchedule(scheduleValue);
     open();
   }
+  const today = new Date();
+  today.setDate(today.getDate() - 1);
+  today.setHours(23, 59, 59);
+  const isBeforeToday = date < today;
 
   return (
     <div className={viewStyles.container}>
@@ -51,12 +55,21 @@ const ScheduleView = ({
           </span>
         </div>
         <div>
-          <CustomButton
-            size="sm"
-            title="스케줄 추가하기"
-            styleType="line"
-            onClick={open}
-          />
+          <Tooltip
+            position="bottom"
+            label="이전 날짜에 스케줄을 추가할 수 없습니다."
+            disabled={!isBeforeToday}
+          >
+            <div>
+              <CustomButton
+                size="sm"
+                title="스케줄 추가하기"
+                styleType="line"
+                onClick={open}
+                disabled={isBeforeToday}
+              />
+            </div>
+          </Tooltip>
           <EditModal
             close={close}
             opened={opened}

--- a/src/containers/photographer/mypage/schedule/daily/schedule-view.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/schedule-view.tsx
@@ -1,0 +1,59 @@
+import { BaseScheduleType, DailyScheduleValue } from "calender-types";
+import { formatTimeString } from "@/utils/date";
+import { Divider } from "@mantine/core";
+import { CustomButton } from "@/components/buttons/common-buttons";
+import { viewStyles } from "./daily.css";
+import ScheduleList from "./schedule-list";
+
+const ScheduleView = ({
+  baseSchedule,
+  dailySchedules,
+  date,
+}: {
+  dailySchedules: DailyScheduleValue;
+  baseSchedule: BaseScheduleType;
+  date: Date;
+}) => {
+  return (
+    <div className={viewStyles.container}>
+      <div className={viewStyles.dateInfo}>
+        <div>
+          <span className={viewStyles.date}>
+            {`${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()} (${date.toLocaleDateString("ko", { weekday: "short" })})`}
+          </span>
+          <span className={viewStyles.baseSchedule}>
+            {baseSchedule.isOff
+              ? "휴무일입니다."
+              : `시작 시간 ${formatTimeString(baseSchedule.startTime)} ~ 종료 시간 ${formatTimeString(baseSchedule.endTime)}`}
+          </span>
+        </div>
+        <div>
+          <CustomButton size="sm" title="스케줄 추가하기" styleType="line" />
+        </div>
+      </div>
+      <Divider />
+      <div className={viewStyles.scheduleWrapper}>
+        <ScheduleList
+          status="OPEN"
+          scheduleData={dailySchedules.filter(
+            (v) => v.scheduleStatus === "OPEN",
+          )}
+        />
+        <ScheduleList
+          status="CLOSED"
+          scheduleData={dailySchedules.filter(
+            (v) => v.scheduleStatus === "CLOSED",
+          )}
+        />
+        <ScheduleList
+          status="CONFIRMED"
+          scheduleData={dailySchedules.filter(
+            (v) => v.scheduleStatus === "CONFIRMED",
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleView;

--- a/src/containers/photographer/mypage/schedule/daily/schedule-view.tsx
+++ b/src/containers/photographer/mypage/schedule/daily/schedule-view.tsx
@@ -1,19 +1,42 @@
-import { BaseScheduleType, DailyScheduleList } from "calender-types";
+import { useState } from "react";
+import {
+  BaseScheduleType,
+  DailyScheduleList,
+  DailyScheduleValue,
+  ScheduleStatusType,
+  TimeUnitType,
+} from "calender-types";
+import { useDisclosure } from "@mantine/hooks";
 import { formatTimeString } from "@/utils/date";
 import { Divider } from "@mantine/core";
 import { CustomButton } from "@/components/buttons/common-buttons";
 import { viewStyles } from "./daily.css";
 import ScheduleList from "./schedule-list";
+import EditModal from "./edit-modal";
 
 const ScheduleView = ({
   baseSchedule,
   dailySchedules,
   date,
+  unit,
 }: {
   dailySchedules: DailyScheduleList;
   baseSchedule: BaseScheduleType;
   date: Date;
+  unit: TimeUnitType;
 }) => {
+  const [selectedSchedule, setSelectedSchedule] = useState<
+    DailyScheduleValue | undefined
+  >();
+  const [opened, { open, close }] = useDisclosure(false, {
+    onClose: () => setSelectedSchedule(undefined),
+  });
+
+  function handleSelectSchedule(scheduleValue: DailyScheduleValue) {
+    setSelectedSchedule(scheduleValue);
+    open();
+  }
+
   return (
     <div className={viewStyles.container}>
       <div className={viewStyles.dateInfo}>
@@ -28,29 +51,34 @@ const ScheduleView = ({
           </span>
         </div>
         <div>
-          <CustomButton size="sm" title="스케줄 추가하기" styleType="line" />
+          <CustomButton
+            size="sm"
+            title="스케줄 추가하기"
+            styleType="line"
+            onClick={open}
+          />
+          <EditModal
+            close={close}
+            opened={opened}
+            baseSchedule={baseSchedule}
+            initValue={selectedSchedule}
+            date={date}
+            unit={unit}
+          />
         </div>
       </div>
       <Divider />
       <div className={viewStyles.scheduleWrapper}>
-        <ScheduleList
-          status="OPEN"
-          scheduleData={dailySchedules.filter(
-            (v) => v.scheduleStatus === "OPEN",
-          )}
-        />
-        <ScheduleList
-          status="CLOSED"
-          scheduleData={dailySchedules.filter(
-            (v) => v.scheduleStatus === "CLOSED",
-          )}
-        />
-        <ScheduleList
-          status="CONFIRMED"
-          scheduleData={dailySchedules.filter(
-            (v) => v.scheduleStatus === "CONFIRMED",
-          )}
-        />
+        {["OPEN", "CLOSED", "CONFIRMED"].map((status) => (
+          <ScheduleList
+            key={status}
+            status={status as ScheduleStatusType}
+            onSelectSchedule={handleSelectSchedule}
+            scheduleData={dailySchedules.filter(
+              (v) => v.scheduleStatus === status,
+            )}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/containers/photographer/mypage/schedule/index.tsx
+++ b/src/containers/photographer/mypage/schedule/index.tsx
@@ -20,7 +20,7 @@ const PhotographerSchedule = ({
       <BaseSchedule unit={unit} currentSchedule={currentSchedule} />
       <Divider />
       <QueryProviders>
-        <DailySchedule baseSchedule={currentSchedule} />
+        <DailySchedule baseSchedule={currentSchedule} unit={unit} />
       </QueryProviders>
     </div>
   );

--- a/src/containers/photographer/mypage/schedule/index.tsx
+++ b/src/containers/photographer/mypage/schedule/index.tsx
@@ -1,4 +1,4 @@
-import { TimeUnitType } from "calender-types";
+import { BaseScheduleForm, TimeUnitType } from "calender-types";
 import { Divider } from "@mantine/core";
 import QueryProviders from "@/containers/common/query-providers";
 import BaseSchedule from "./base";
@@ -11,7 +11,7 @@ const PhotographerSchedule = ({
   currentSchedule,
 }: {
   unit: TimeUnitType;
-  currentSchedule: any;
+  currentSchedule: BaseScheduleForm;
 }) => {
   return (
     <div className={scheduleStyles.container}>
@@ -20,7 +20,7 @@ const PhotographerSchedule = ({
       <BaseSchedule unit={unit} currentSchedule={currentSchedule} />
       <Divider />
       <QueryProviders>
-        <DailySchedule />
+        <DailySchedule baseSchedule={currentSchedule} />
       </QueryProviders>
     </div>
   );

--- a/src/containers/photographer/mypage/schedule/index.tsx
+++ b/src/containers/photographer/mypage/schedule/index.tsx
@@ -1,8 +1,10 @@
 import { TimeUnitType } from "calender-types";
 import { Divider } from "@mantine/core";
+import QueryProviders from "@/containers/common/query-providers";
 import BaseSchedule from "./base";
 import TimeBlock from "./time-block";
 import { scheduleStyles } from "./schedule.css";
+import DailySchedule from "./daily";
 
 const PhotographerSchedule = ({
   unit,
@@ -17,7 +19,9 @@ const PhotographerSchedule = ({
       <Divider />
       <BaseSchedule unit={unit} currentSchedule={currentSchedule} />
       <Divider />
-      <div>날짜별 스케줄</div>
+      <QueryProviders>
+        <DailySchedule />
+      </QueryProviders>
     </div>
   );
 };

--- a/src/containers/photographer/mypage/schedule/schedule.css.ts
+++ b/src/containers/photographer/mypage/schedule/schedule.css.ts
@@ -23,7 +23,7 @@ export const scheduleStyles = styleVariants({
   body: {
     display: "grid",
     gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
-    paddingTop: 16,
+    paddingTop: 12,
     gap: 16,
     columnGap: 30,
   },

--- a/src/services/client/photographer/mypage/schedule.ts
+++ b/src/services/client/photographer/mypage/schedule.ts
@@ -57,7 +57,6 @@ export async function getDailySchedules(requestedDate: Date) {
       startTime: DateTime.fromFormat(startTime, "HH:mm:ss"),
       endTime: DateTime.fromFormat(endTime, "HH:mm:ss"),
     };
-    console.log(newSchedule);
     if (prevList) {
       dailySchedules.set(day, [...prevList, newSchedule]);
     } else {

--- a/src/services/client/photographer/mypage/schedule.ts
+++ b/src/services/client/photographer/mypage/schedule.ts
@@ -2,7 +2,7 @@ import {
   BaseScheduleForm,
   BaseScheduleResponse,
   DailyScheduleResponse,
-  DailyScheduleValue,
+  DailyScheduleList,
   DaysType,
   TimeUnitType,
 } from "calender-types";
@@ -43,7 +43,7 @@ export async function getDailySchedules(requestedDate: Date) {
     })
     .json<{ data: DailyScheduleResponse }>();
 
-  const dailySchedules: Map<number, DailyScheduleValue> = new Map();
+  const dailySchedules: Map<number, DailyScheduleList> = new Map();
 
   data.forEach(({ scheduleId, scheduleStatus, date, startTime, endTime }) => {
     const { day } = DateTime.fromISO(date);
@@ -52,8 +52,8 @@ export async function getDailySchedules(requestedDate: Date) {
     const newSchedule = {
       scheduleId,
       scheduleStatus,
-      startTime: DateTime.fromFormat(startTime, "HH:MM:ss"),
-      endTime: DateTime.fromFormat(endTime, "HH:MM:ss"),
+      startTime: DateTime.fromFormat(startTime, "HH:mm:ss"),
+      endTime: DateTime.fromFormat(endTime, "HH:mm:ss"),
     };
     if (prevList) {
       dailySchedules.set(day, [...prevList, newSchedule]);

--- a/src/services/client/photographer/mypage/schedule.ts
+++ b/src/services/client/photographer/mypage/schedule.ts
@@ -1,9 +1,12 @@
 import {
   BaseScheduleForm,
   BaseScheduleResponse,
+  DailyScheduleResponse,
+  DailyScheduleValue,
   DaysType,
   TimeUnitType,
 } from "calender-types";
+import { DateTime } from "luxon";
 import apiClient from "../../core";
 
 export async function putNewUnit(data: TimeUnitType) {
@@ -24,7 +27,40 @@ export async function putNewBaseSchedule(form: BaseScheduleForm) {
       };
     },
   );
+
   await apiClient.put("photographer/schedule/base", {
     json: { data },
   });
+}
+
+export async function getDailySchedules(requestedDate: Date) {
+  const { data } = await apiClient
+    .get("photographer/schedule/daily", {
+      json: {
+        year: requestedDate.getFullYear(),
+        monthValue: requestedDate.getMonth() + 1,
+      },
+    })
+    .json<{ data: DailyScheduleResponse }>();
+
+  const dailySchedules: Map<number, DailyScheduleValue> = new Map();
+
+  data.forEach(({ scheduleId, scheduleStatus, date, startTime, endTime }) => {
+    const { day } = DateTime.fromISO(date);
+
+    const prevList = dailySchedules.get(day);
+    const newSchedule = {
+      scheduleId,
+      scheduleStatus,
+      startTime: DateTime.fromFormat(startTime, "HH:MM:ss"),
+      endTime: DateTime.fromFormat(endTime, "HH:MM:ss"),
+    };
+    if (prevList) {
+      dailySchedules.set(day, [...prevList, newSchedule]);
+    } else {
+      dailySchedules.set(day, [newSchedule]);
+    }
+  });
+
+  return dailySchedules;
 }

--- a/src/services/client/photographer/mypage/schedule.ts
+++ b/src/services/client/photographer/mypage/schedule.ts
@@ -58,7 +58,7 @@ export async function getDailySchedules(requestedDate: Date) {
       endTime: DateTime.fromFormat(endTime, "HH:mm:ss"),
     };
     if (prevList) {
-      dailySchedules.set(day, [...prevList, newSchedule]);
+      prevList.push(newSchedule);
     } else {
       dailySchedules.set(day, [newSchedule]);
     }

--- a/src/services/client/photographer/mypage/schedule.ts
+++ b/src/services/client/photographer/mypage/schedule.ts
@@ -5,6 +5,7 @@ import {
   DailyScheduleList,
   DaysType,
   TimeUnitType,
+  DailyScheduleValue,
 } from "calender-types";
 import { DateTime } from "luxon";
 import apiClient from "../../core";
@@ -52,9 +53,11 @@ export async function getDailySchedules(requestedDate: Date) {
     const newSchedule = {
       scheduleId,
       scheduleStatus,
+      date: DateTime.fromFormat(date, "yyyy-MM-dd"),
       startTime: DateTime.fromFormat(startTime, "HH:mm:ss"),
       endTime: DateTime.fromFormat(endTime, "HH:mm:ss"),
     };
+    console.log(newSchedule);
     if (prevList) {
       dailySchedules.set(day, [...prevList, newSchedule]);
     } else {
@@ -63,4 +66,32 @@ export async function getDailySchedules(requestedDate: Date) {
   });
 
   return dailySchedules;
+}
+
+export async function postDailySchedule(newSchedule: DailyScheduleValue) {
+  const data = {
+    scheduleStatus: newSchedule.scheduleStatus,
+    date: newSchedule.date.toFormat("yyyy-MM-dd"),
+    startTime: newSchedule.startTime.toFormat("HH:mm:ss"),
+    endTime: newSchedule.endTime.toFormat("HH:mm:ss"),
+  };
+  await apiClient.post("photographer/schedule/daily", {
+    json: { data },
+  });
+}
+
+export async function putDailySchedule(newSchedule: DailyScheduleValue) {
+  const data = {
+    scheduleStatus: newSchedule.scheduleStatus,
+    date: newSchedule.date.toFormat("yyyy-MM-dd"),
+    startTime: newSchedule.startTime.toFormat("HH:mm:ss"),
+    endTime: newSchedule.endTime.toFormat("HH:mm:ss"),
+  };
+  await apiClient.put(`photographer/schedule/daily/${newSchedule.scheduleId}`, {
+    json: { data },
+  });
+}
+
+export async function deleteDailySchedule(scheduleId: number) {
+  await apiClient.delete(`photographer/schedule/daily/${scheduleId}`);
 }

--- a/src/services/common/error.ts
+++ b/src/services/common/error.ts
@@ -24,6 +24,11 @@ export const CUSTOMED_CODE: { [key: string]: string } = {
   MAXIMUM_UPLOAD_SIZE_EXCEEDED: "이미지의 용량이 너무 큽니다.",
   NOT_FOUND_ESSENTIAL_TITLE:
     "공지사항에는 '취소 및 환불 규정', '예약 변경 규정'이 필수로 포함되어야 합니다.",
+  DAILY_SCHEDULE_NOT_FOUND: "해당하는 날짜별 스케줄을 찾을 수 없습니다.",
+  DAILY_SCHEDULE_OVERLAP: "해당 일정에 이미 등록된 스케줄이 있습니다.",
+  DAILY_SCHEDULE_IN_PAST: "현재 시점 이전의 스케줄은 등록할 수 없습니다.",
+  START_TIME_AFTER_END_TIME:
+    "시작 시간을 종료 시간보다 늦게 설정할 수 없습니다.",
 };
 
 const CUSTOMED_STATUS: { [key: number]: string } = {

--- a/src/services/server/photographer/mypage/schedule.ts
+++ b/src/services/server/photographer/mypage/schedule.ts
@@ -11,7 +11,8 @@ export async function getCurrentBaseSchedule(): Promise<BaseScheduleForm> {
     .json<{ data: BaseScheduleResponse }>();
   return data.reduce((acc, item) => {
     acc[item.dayOfWeek] = {
-      ...item,
+      endTime: item.endTime,
+      startTime: item.startTime,
       isOff: item.operationStatus === "INACTIVE",
     };
     return acc;

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -1,4 +1,6 @@
 declare module "calender-types" {
+  import { DateTime } from "luxon";
+
   type ScheduleStatusType = "CONFIRMED" | "OPEN" | "CLOSED";
   type TimeUnitType = "THIRTY_MINUTES" | "SIXTY_MINUTES";
   type DaysType =

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -37,10 +37,11 @@ declare module "calender-types" {
     endTime: string;
   }[];
 
-  type DailyScheduleValue = {
-    scheduleId: number;
+  type DailyScheduleList = (DailyScheduleValue & { scheduleId: number })[];
+
+  interface DailyScheduleValue {
     scheduleStatus: ScheduleStatusType;
     startTime: DateTime;
     endTime: DateTime;
-  }[];
+  }
 }

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -37,11 +37,13 @@ declare module "calender-types" {
     endTime: string;
   }[];
 
-  type DailyScheduleList = (DailyScheduleValue & { scheduleId: number })[];
+  type DailyScheduleList = DailyScheduleValue[];
 
   interface DailyScheduleValue {
     scheduleStatus: ScheduleStatusType;
     startTime: DateTime;
     endTime: DateTime;
+    date: DateTime;
+    scheduleId: number;
   }
 }

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -1,4 +1,5 @@
 declare module "calender-types" {
+  type ScheduleStatusType = "CONFIRMED" | "OPEN" | "CLOSED";
   type TimeUnitType = "THIRTY_MINUTES" | "SIXTY_MINUTES";
   type DaysType =
     | "MONDAY"
@@ -28,7 +29,7 @@ declare module "calender-types" {
 
   type DailyScheduleResponse = {
     scheduleId: number;
-    scheduleStatus: "OPEN" | "CLOSED" | "CONFIRMED";
+    scheduleStatus: ScheduleStatusType;
     date: string;
     startTime: string;
     endTime: string;
@@ -36,7 +37,7 @@ declare module "calender-types" {
 
   type DailyScheduleValue = {
     scheduleId: number;
-    scheduleStatus: "CONFIRMED" | "OPEN" | "CLOSED";
+    scheduleStatus: ScheduleStatusType;
     startTime: DateTime;
     endTime: DateTime;
   }[];

--- a/src/types/calender-types.d.ts
+++ b/src/types/calender-types.d.ts
@@ -25,4 +25,19 @@ declare module "calender-types" {
     endTime: string;
     operationStatus: "ACTIVE" | "INACTIVE";
   }[];
+
+  type DailyScheduleResponse = {
+    scheduleId: number;
+    scheduleStatus: "OPEN" | "CLOSED" | "CONFIRMED";
+    date: string;
+    startTime: string;
+    endTime: string;
+  }[];
+
+  type DailyScheduleValue = {
+    scheduleId: number;
+    scheduleStatus: "CONFIRMED" | "OPEN" | "CLOSED";
+    startTime: DateTime;
+    endTime: DateTime;
+  }[];
 }


### PR DESCRIPTION
## 체크리스트
- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
* 날짜별 스케줄 관련 기능
캘린더 기반 월별 조회, 기존 스케줄 수정 및 삭제, 신규 스케줄 추가 기능을 구현했습니다.
(내부 예약의 일정 확정 기능 관련 수정 사항은 백엔드와 같이 FU-175 스토리 티켓 안에서 작업할 예정입니다.)

## 고민한 사항
* `edit-modal`의 역할 분리
기존 스케줄을 상세 조회했을 때의 모달과(삭제, 수정 가능) 신규 스케줄을 추가할 때의 모달(추가 가능)의 경우 중복되는 코드가 많을 것 같아서 하나의 컴포넌트로 통합하고, initValue의 유무를 기준으로 내부 동작이나 UI를 다르게 처리하고 있습니다. (조금 복잡한 컴포넌트가 되어서 리팩토링할 여지가 없을지 고민이 됩니다 😓)

* 월별 데이터 페칭 - 일별 날짜 선택 관리
1. selectedDate 상태 하나만 두고, 해당 객체의 year, month 값을 queryKey에 포함해 변경시 데이터 페칭이 발생하도록 설정
처음엔 현재 캘린더에서 보고 있는 월의 정보 / 사용자가 선택한 날짜의 정보를 따로 상태 관리하는 방식을 구현했었는데, 하나의 Date 객체만 두고 선택된 월의 정보만 쿼리 키에 포함시킬 수 있어서 상태를 통합했습니다. 

2. 캘린더 컴포넌트에서 월을 변경했을 때 selectedDate를 해당 월의 1일으로 변경
월이 바뀌면 데이터 페칭이 새로 발생하기 때문에, selectedDate를 그대로 유지하려면 기존에 받았던 데이터 중 selectedDate에 해당하는 날짜별 스케줄 정보만 따로 상태 관리를 할 필요가 있었습니다. 별도로 상태를 관리하면서까지 월이 바뀌었을 때 선택한 날짜의 스케줄 정보를 계속 보여 주는 게 필요하지는 않을 것 같아서, 다른 캘린더의 동작을 참고해 월이 바뀌면 선택한 날짜도 해당 월 1일로 자동 변경되게 처리했습니다.

* Date 리팩토링
luxon 라이브러리를 새로 도입하면서 아직은 luxon의 DateTime, 네이티브 Date, string이 혼용되고 있는 상태입니다. 😵‍💫 스케줄 관련 작업을 전체적으로 끝내고 리팩토링하는 게 좋을 것 같아서 아직 크게 건드리지는 않았는데, 이번에 DateTime 메서드 중 toFormat, fromFormat 등을 반복 사용하면서 별도로 추출해 볼지 고민도 들었습니다. 메서드에 포맷 정보를 문자열로 전달해 주는데, 문자열만 상수로 정의하는 방식 / 따로 util 함수를 작성해서 처리하는 방식 중 더 나은 게 있을지 고려 중입니다. (기록 겸 작성합니다!)

## 리뷰 요청사항
`src/services/client/photographer/mypage/schedule.ts` 날짜별 스케줄 api 요청 함수
`src/containers/photographer/mypage/schedule/daily/edit-modal.tsx` 호출 위치 (handleSubmit, handleDelete)
`src/services/common/error.ts` 에러 메시지 추가

그리고 에러 메시지 추가하다가, 현재 시점 이전의 날짜에 대해서는 아예 "스케줄 추가하기" 버튼을 표시하지 않는 게 나을까 하는 생각도 들었는데 의견 부탁드립니다!

## 스크린샷
![FU-347](https://github.com/user-attachments/assets/8e0f8a5f-196a-41f9-b257-2d8d61de6e4f)
(더미 데이터로 테스트해서 월이 바뀌어도 같은 데이터가 보이는 중입니다!)


[FU-347]: https://for-u.atlassian.net/browse/FU-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ